### PR TITLE
feat(canonicalize): pin JCS library and ship nixfleet-canonicalize (#12)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,6 +1538,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nixfleet-canonicalize"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "serde_jcs",
+ "serde_json",
+]
+
+[[package]]
 name = "nixfleet-cli"
 version = "0.1.0"
 dependencies = [
@@ -2278,6 +2287,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "ryu-js"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2358,6 +2373,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_jcs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a60f3fda61525e439ef6d67422118f11e986566997d9021c56867ad814a0aa"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/nixfleet-canonicalize/Cargo.toml
+++ b/crates/nixfleet-canonicalize/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "nixfleet-canonicalize"
+version = "0.2.0"
+edition = "2021"
+description = "JCS (RFC 8785) canonicalizer for NixFleet signed artifacts"
+license = "MIT"
+repository = "https://github.com/arcanesys/nixfleet"
+homepage = "https://github.com/arcanesys/nixfleet"
+authors = ["nixfleet contributors"]
+
+[lib]
+name = "nixfleet_canonicalize"
+path = "src/lib.rs"
+
+[[bin]]
+name = "nixfleet-canonicalize"
+path = "src/main.rs"
+
+[dependencies]
+serde_jcs = "0.2"
+serde_json = "1"
+anyhow = "1"

--- a/crates/nixfleet-canonicalize/src/lib.rs
+++ b/crates/nixfleet-canonicalize/src/lib.rs
@@ -1,2 +1,18 @@
 //! JCS canonicalization library backing the `nixfleet-canonicalize`
-//! binary. Implementation follows in the next task.
+//! binary. Pinned to `serde_jcs` per `docs/CONTRACTS.md §III`.
+//!
+//! Every signer and verifier in the fleet goes through this one
+//! function — do not reimplement in Nix, shell, or ad-hoc Rust.
+
+use anyhow::{Context, Result};
+
+/// Canonicalize an arbitrary JSON string to JCS (RFC 8785) form.
+///
+/// Errors on malformed JSON. The returned string is the exact byte
+/// sequence every signer must feed to its signature primitive and
+/// every verifier must reconstruct before verification.
+pub fn canonicalize(input: &str) -> Result<String> {
+    let value: serde_json::Value =
+        serde_json::from_str(input).context("input is not valid JSON")?;
+    serde_jcs::to_string(&value).context("JCS canonicalization failed")
+}

--- a/crates/nixfleet-canonicalize/src/lib.rs
+++ b/crates/nixfleet-canonicalize/src/lib.rs
@@ -1,0 +1,2 @@
+//! JCS canonicalization library backing the `nixfleet-canonicalize`
+//! binary. Implementation follows in the next task.

--- a/crates/nixfleet-canonicalize/src/main.rs
+++ b/crates/nixfleet-canonicalize/src/main.rs
@@ -1,8 +1,34 @@
-//! Placeholder. The stdin/stdout wrapper lands in a later task.
-//! This file exists so `[[bin]] path = "src/main.rs"` resolves and
-//! workspace-level `cargo test --workspace` does not fail with
-//! "can't find bin" while the real binary is still being built up.
+//! `nixfleet-canonicalize` — stdin JSON → JCS canonical stdout.
+//!
+//! Shell-invocable canonicalizer for Stream A's CI signing
+//! pipeline. Exit codes:
+//! - 0 — canonical bytes written to stdout
+//! - 1 — input was not valid JSON or canonicalization failed
+//! - 2 — I/O error reading stdin or writing stdout
 
-fn main() {
-    unimplemented!("nixfleet-canonicalize: binary wrapper lands in a later task")
+use std::io::{self, Read, Write};
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let mut input = String::new();
+    if let Err(err) = io::stdin().read_to_string(&mut input) {
+        eprintln!("nixfleet-canonicalize: read stdin: {err}");
+        return ExitCode::from(2);
+    }
+
+    let canonical = match nixfleet_canonicalize::canonicalize(&input) {
+        Ok(s) => s,
+        Err(err) => {
+            eprintln!("nixfleet-canonicalize: {err:#}");
+            return ExitCode::from(1);
+        }
+    };
+
+    let mut stdout = io::stdout().lock();
+    if let Err(err) = stdout.write_all(canonical.as_bytes()) {
+        eprintln!("nixfleet-canonicalize: write stdout: {err}");
+        return ExitCode::from(2);
+    }
+
+    ExitCode::SUCCESS
 }

--- a/crates/nixfleet-canonicalize/src/main.rs
+++ b/crates/nixfleet-canonicalize/src/main.rs
@@ -1,0 +1,8 @@
+//! Placeholder. The stdin/stdout wrapper lands in a later task.
+//! This file exists so `[[bin]] path = "src/main.rs"` resolves and
+//! workspace-level `cargo test --workspace` does not fail with
+//! "can't find bin" while the real binary is still being built up.
+
+fn main() {
+    unimplemented!("nixfleet-canonicalize: binary wrapper lands in a later task")
+}

--- a/crates/nixfleet-canonicalize/tests/fixtures/jcs-golden.canonical
+++ b/crates/nixfleet-canonicalize/tests/fixtures/jcs-golden.canonical
@@ -1,0 +1,1 @@
+{"a":{"x":[3,1,2],"y":true,"z":null},"b":2,"schemaVersion":1}

--- a/crates/nixfleet-canonicalize/tests/fixtures/jcs-golden.json
+++ b/crates/nixfleet-canonicalize/tests/fixtures/jcs-golden.json
@@ -1,0 +1,1 @@
+{"b":2,"a":{"z":null,"y":true,"x":[3,1,2]},"schemaVersion":1}

--- a/crates/nixfleet-canonicalize/tests/jcs_golden.rs
+++ b/crates/nixfleet-canonicalize/tests/jcs_golden.rs
@@ -1,0 +1,20 @@
+//! Golden-file JCS test (`docs/CONTRACTS.md §III`).
+//!
+//! Asserts the canonicalizer produces byte-exact output matching
+//! the committed golden. Runs on every push via pre-push
+//! `cargo nextest run --workspace`. Any drift = signature contract
+//! broken.
+
+use nixfleet_canonicalize::canonicalize;
+
+const GOLDEN_INPUT: &str = include_str!("fixtures/jcs-golden.json");
+const GOLDEN_CANONICAL: &str = include_str!("fixtures/jcs-golden.canonical");
+
+#[test]
+fn jcs_golden_bytes_match() {
+    let produced = canonicalize(GOLDEN_INPUT).expect("canonicalize golden input");
+    assert_eq!(
+        produced, GOLDEN_CANONICAL,
+        "JCS output drifted from golden — signature contract broken"
+    );
+}

--- a/crates/nixfleet-canonicalize/tests/jcs_golden.rs
+++ b/crates/nixfleet-canonicalize/tests/jcs_golden.rs
@@ -25,3 +25,14 @@ fn canonicalize_is_idempotent() {
     let twice = canonicalize(&once).expect("canonicalize canonical form");
     assert_eq!(once, twice, "canonical form must be a fixed point");
 }
+
+#[test]
+fn reordering_input_does_not_change_canonical_output() {
+    let reordered = r#"{"schemaVersion":1,"a":{"x":[3,1,2],"z":null,"y":true},"b":2}"#;
+    let original = canonicalize(GOLDEN_INPUT).expect("canonicalize original");
+    let shuffled = canonicalize(reordered).expect("canonicalize shuffled");
+    assert_eq!(
+        original, shuffled,
+        "canonical output must be invariant under input key ordering"
+    );
+}

--- a/crates/nixfleet-canonicalize/tests/jcs_golden.rs
+++ b/crates/nixfleet-canonicalize/tests/jcs_golden.rs
@@ -18,3 +18,10 @@ fn jcs_golden_bytes_match() {
         "JCS output drifted from golden — signature contract broken"
     );
 }
+
+#[test]
+fn canonicalize_is_idempotent() {
+    let once = canonicalize(GOLDEN_INPUT).expect("canonicalize once");
+    let twice = canonicalize(&once).expect("canonicalize canonical form");
+    assert_eq!(once, twice, "canonical form must be a fixed point");
+}

--- a/crates/nixfleet-canonicalize/tests/jcs_golden.rs
+++ b/crates/nixfleet-canonicalize/tests/jcs_golden.rs
@@ -36,3 +36,9 @@ fn reordering_input_does_not_change_canonical_output() {
         "canonical output must be invariant under input key ordering"
     );
 }
+
+#[test]
+fn invalid_json_is_rejected() {
+    let result = canonicalize("{not json");
+    assert!(result.is_err(), "invalid JSON must be rejected");
+}

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -158,9 +158,9 @@ Four keys. Everything else is derived. For each: **who holds the private key, wh
 
 **JCS (RFC 8785) with a single Rust implementation, byte-identical across all signers and verifiers.**
 
-- **Library choice.** TBD — Stream C's first commit must pin one (`serde_jcs` or equivalent) and document it here. Requirements: RFC 8785 conformant, handles all JSON edge cases (Unicode NFC, number precision, key sorting on non-ASCII).
-- **Golden-file test.** `tests/fixtures/jcs-golden.json` → `tests/fixtures/jcs-golden.canonical` → known ed25519 signature. Test runs on every CI and fails any subtle drift.
-- **Usage.** Every signed artifact (fleet.resolved, probe output) is canonicalized via this single library before signing and before verification. No ad-hoc serializers.
+- **Library choice.** Pinned to [`serde_jcs`](https://crates.io/crates/serde_jcs) `0.2`, hosted by `crates/nixfleet-canonicalize`. Rationale: direct RFC 8785 implementation over `serde_json::Value`; handles UTF-16 key sorting and ECMAScript number formatting per spec. Any change to this pin is a contract change (§VII) requiring signoff from every stream that signs or verifies artifacts (A, B, C).
+- **Golden-file test.** `crates/nixfleet-canonicalize/tests/fixtures/jcs-golden.{json,canonical}` with byte-exact equality asserted in `tests/jcs_golden.rs`. Runs on every push via pre-push `cargo nextest run --workspace`; fails loudly on any drift. The ed25519-signed-bytes extension of this fixture lands alongside the CI release key.
+- **Usage.** Every signed artifact (fleet.resolved, probe output) is canonicalized via this single library before signing and before verification. No ad-hoc serializers in Nix, shell, or other crates.
 
 When Stream B needs to produce a JCS-canonical artifact (e.g. CI signing fleet.resolved), it invokes the same Rust canonicalizer via a small shell tool (`nixfleet-canonicalize`). Do not reimplement in Nix or shell.
 

--- a/docs/superpowers/plans/feat-12-canonicalize-jcs-pin.md
+++ b/docs/superpowers/plans/feat-12-canonicalize-jcs-pin.md
@@ -1,0 +1,592 @@
+# JCS Canonicalize Pin — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL — use `superpowers:executing-plans` or `superpowers:subagent-driven-development` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal.** Pin the RFC 8785 JCS library for the whole v0.2 fleet, ship `crates/nixfleet-canonicalize` (lib + thin stdin/stdout binary), prove byte-exact determinism with a golden-file test, and amend `docs/CONTRACTS.md §III` to lock the pin.
+
+**Architecture.** New Rust crate at `crates/nixfleet-canonicalize/`. Lib exports `pub fn canonicalize(input: &str) -> anyhow::Result<String>` delegating to `serde_jcs::to_string(&serde_json::Value)`. Thin binary reads stdin, canonicalizes, writes stdout. No `nixfleet-proto` crate (ships later with the reconciler).
+
+**Tech stack.** Rust edition 2021, `serde_jcs = "0.2"`, `serde_json = "1"`, `anyhow = "1"`. Integration tests at `tests/*.rs`. No workspace-level changes.
+
+**Repo.** `abstracts33d/nixfleet` (origin). Worktree: `.worktrees/stream-c`. Branch after pre-flight: `feat/12-canonicalize-jcs-pin`.
+
+**Execution convention.** Heavy commands (anything running `cargo test --workspace`, `cargo nextest run --workspace`, `nix build`, `nix flake check`, or `nix develop`) are marked **[USER RUNS]** — the implementing agent MUST NOT run them and should wait for the user's result. Cheap per-crate commands (`cargo build -p <crate>`, `cargo test -p <crate>`, `cargo metadata -p <crate>`) may be run by the agent.
+
+---
+
+## File Structure
+
+**Create.**
+- `crates/nixfleet-canonicalize/Cargo.toml`
+- `crates/nixfleet-canonicalize/src/lib.rs`
+- `crates/nixfleet-canonicalize/src/main.rs`
+- `crates/nixfleet-canonicalize/tests/jcs_golden.rs`
+- `crates/nixfleet-canonicalize/tests/fixtures/jcs-golden.json`
+- `crates/nixfleet-canonicalize/tests/fixtures/jcs-golden.canonical` (61 bytes, no trailing newline)
+
+**Edit.**
+- `docs/CONTRACTS.md` (§III only)
+- `TODO.md` (one-line append)
+- `Cargo.lock` (auto-regenerated; do not hand-edit)
+
+**Must not touch.** `lib/`, `modules/`, `spike/`, `crates/{agent,cli,control-plane,shared}`.
+
+---
+
+## Task 0 — Pre-flight: rename the branch
+
+Local-only rename; no remote exists yet.
+
+- [ ] **Step 1.** Confirm current branch.
+
+  Run: `git -C /home/s33d/dev/arcanesys/nixfleet/.worktrees/stream-c branch --show-current`
+  Expected: `feat/12-canonicalize-proto`
+
+- [ ] **Step 2.** Rename.
+
+  Run: `git -C /home/s33d/dev/arcanesys/nixfleet/.worktrees/stream-c branch -m feat/12-canonicalize-proto feat/12-canonicalize-jcs-pin`
+
+- [ ] **Step 3.** Verify.
+
+  Run: `git -C /home/s33d/dev/arcanesys/nixfleet/.worktrees/stream-c branch --show-current`
+  Expected: `feat/12-canonicalize-jcs-pin`
+
+No commit — ref rename only, nothing staged.
+
+---
+
+## Task 1 — Cargo.toml + lib stub + main placeholder
+
+A stub `src/lib.rs` (module-level doc only) lets Task 2's test file compile against an existing lib target; the test then fails with `cannot find function` instead of "file not found". A placeholder `src/main.rs` is needed because `Cargo.toml` declares `[[bin]] path = "src/main.rs"` — without the file, `cargo check -p nixfleet-canonicalize` and the workspace-level `cargo test --workspace` fail with "can't find bin at path" before reaching any test logic. Task 7 overwrites the placeholder with the real stdin/stdout wrapper.
+
+**Files.**
+- Create `crates/nixfleet-canonicalize/Cargo.toml`
+- Create `crates/nixfleet-canonicalize/src/lib.rs` (stub)
+- Create `crates/nixfleet-canonicalize/src/main.rs` (placeholder; overwritten in Task 7)
+
+- [ ] **Step 1.** Write the manifest.
+
+  File: `crates/nixfleet-canonicalize/Cargo.toml`
+  ```toml
+  [package]
+  name = "nixfleet-canonicalize"
+  version = "0.2.0"
+  edition = "2021"
+  description = "JCS (RFC 8785) canonicalizer for NixFleet signed artifacts"
+  license = "MIT"
+  repository = "https://github.com/arcanesys/nixfleet"
+  homepage = "https://github.com/arcanesys/nixfleet"
+  authors = ["nixfleet contributors"]
+
+  [lib]
+  name = "nixfleet_canonicalize"
+  path = "src/lib.rs"
+
+  [[bin]]
+  name = "nixfleet-canonicalize"
+  path = "src/main.rs"
+
+  [dependencies]
+  serde_jcs = "0.2"
+  serde_json = "1"
+  anyhow = "1"
+  ```
+
+- [ ] **Step 2.** Write an empty lib stub so the crate compiles before any function exists.
+
+  File: `crates/nixfleet-canonicalize/src/lib.rs`
+  ```rust
+  //! JCS canonicalization library backing the `nixfleet-canonicalize`
+  //! binary. Implementation follows in the next task.
+  ```
+
+- [ ] **Step 3.** Write the placeholder binary so the `[[bin]]` target builds. Task 7 overwrites this.
+
+  File: `crates/nixfleet-canonicalize/src/main.rs`
+  ```rust
+  //! Placeholder. The stdin/stdout wrapper lands in a later task.
+  //! This file exists so `[[bin]] path = "src/main.rs"` resolves and
+  //! workspace-level `cargo test --workspace` does not fail with
+  //! "can't find bin" while the real binary is still being built up.
+
+  fn main() {
+      unimplemented!("nixfleet-canonicalize: binary wrapper lands in a later task")
+  }
+  ```
+
+- [ ] **Step 4.** Verify cargo picks up the crate and resolves `serde_jcs 0.2`.
+
+  Run: `cargo metadata --format-version 1 --manifest-path crates/nixfleet-canonicalize/Cargo.toml 2>&1 | head -c 300`
+  Expected: JSON beginning with `{"packages":[...` mentioning `nixfleet-canonicalize`. No error. `Cargo.lock` is updated with `serde_jcs` + transitive deps.
+
+- [ ] **Step 5.** Verify the full crate (lib + placeholder bin) compiles.
+
+  Run: `cargo check -p nixfleet-canonicalize 2>&1 | tail -5`
+  Expected: `Finished` (no errors).
+
+- [ ] **Step 6.** Commit.
+
+  ```bash
+  git add crates/nixfleet-canonicalize/Cargo.toml crates/nixfleet-canonicalize/src/lib.rs crates/nixfleet-canonicalize/src/main.rs Cargo.lock
+  git commit -m "feat(canonicalize): scaffold crate with pinned serde_jcs 0.2"
+  ```
+
+---
+
+## Task 2 — RED: golden-file test + fixtures
+
+Test must fail to compile with `cannot find function \`canonicalize\``.
+
+**Files.**
+- Create `crates/nixfleet-canonicalize/tests/fixtures/jcs-golden.json`
+- Create `crates/nixfleet-canonicalize/tests/fixtures/jcs-golden.canonical`
+- Create `crates/nixfleet-canonicalize/tests/jcs_golden.rs`
+
+- [ ] **Step 1.** Write input fixture.
+
+  File: `crates/nixfleet-canonicalize/tests/fixtures/jcs-golden.json`
+  ```
+  {"b":2,"a":{"z":null,"y":true,"x":[3,1,2]},"schemaVersion":1}
+  ```
+
+- [ ] **Step 2.** Write expected canonical fixture. **Exactly 61 bytes, no trailing newline.**
+
+  File: `crates/nixfleet-canonicalize/tests/fixtures/jcs-golden.canonical`
+
+  Content (single line, no trailing newline):
+  ```
+  {"a":{"x":[3,1,2],"y":true,"z":null},"b":2,"schemaVersion":1}
+  ```
+
+- [ ] **Step 3.** Verify byte count.
+
+  Run: `wc -c crates/nixfleet-canonicalize/tests/fixtures/jcs-golden.canonical`
+  Expected: `61 crates/nixfleet-canonicalize/tests/fixtures/jcs-golden.canonical`
+
+  If the count is 62, an editor or write tool appended a newline. Strip it:
+  ```bash
+  truncate -s 61 crates/nixfleet-canonicalize/tests/fixtures/jcs-golden.canonical
+  wc -c crates/nixfleet-canonicalize/tests/fixtures/jcs-golden.canonical
+  ```
+  Re-verify the output is exactly `61`.
+
+- [ ] **Step 4.** Write the failing golden test.
+
+  File: `crates/nixfleet-canonicalize/tests/jcs_golden.rs`
+  ```rust
+  //! Golden-file JCS test (`docs/CONTRACTS.md §III`).
+  //!
+  //! Asserts the canonicalizer produces byte-exact output matching
+  //! the committed golden. Runs on every push via pre-push
+  //! `cargo nextest run --workspace`. Any drift = signature contract
+  //! broken.
+
+  use nixfleet_canonicalize::canonicalize;
+
+  const GOLDEN_INPUT: &str = include_str!("fixtures/jcs-golden.json");
+  const GOLDEN_CANONICAL: &str = include_str!("fixtures/jcs-golden.canonical");
+
+  #[test]
+  fn jcs_golden_bytes_match() {
+      let produced = canonicalize(GOLDEN_INPUT).expect("canonicalize golden input");
+      assert_eq!(
+          produced, GOLDEN_CANONICAL,
+          "JCS output drifted from golden — signature contract broken"
+      );
+  }
+  ```
+
+- [ ] **Step 5.** Verify the test FAILS to compile (RED).
+
+  Run: `cargo build -p nixfleet-canonicalize --tests 2>&1 | tail -10`
+  Expected: error message referring to `cannot find function \`canonicalize\`` or `unresolved import \`nixfleet_canonicalize::canonicalize\``. NO green build.
+
+- [ ] **Step 6.** Commit the failing test (tests-first discipline).
+
+  ```bash
+  git add crates/nixfleet-canonicalize/tests
+  git commit -m "test(canonicalize): add failing golden-file test and fixtures"
+  ```
+
+---
+
+## Task 3 — GREEN: implement canonicalize()
+
+**Files.** Modify `crates/nixfleet-canonicalize/src/lib.rs`.
+
+- [ ] **Step 1.** Replace the stub with the minimal implementation.
+
+  File: `crates/nixfleet-canonicalize/src/lib.rs` (full replacement)
+  ```rust
+  //! JCS canonicalization library backing the `nixfleet-canonicalize`
+  //! binary. Pinned to `serde_jcs` per `docs/CONTRACTS.md §III`.
+  //!
+  //! Every signer and verifier in the fleet goes through this one
+  //! function — do not reimplement in Nix, shell, or ad-hoc Rust.
+
+  use anyhow::{Context, Result};
+
+  /// Canonicalize an arbitrary JSON string to JCS (RFC 8785) form.
+  ///
+  /// Errors on malformed JSON. The returned string is the exact byte
+  /// sequence every signer must feed to its signature primitive and
+  /// every verifier must reconstruct before verification.
+  pub fn canonicalize(input: &str) -> Result<String> {
+      let value: serde_json::Value =
+          serde_json::from_str(input).context("input is not valid JSON")?;
+      serde_jcs::to_string(&value).context("JCS canonicalization failed")
+  }
+  ```
+
+- [ ] **Step 2.** Verify the golden test passes.
+
+  Run: `cargo test -p nixfleet-canonicalize --test jcs_golden 2>&1 | tail -15`
+  Expected: `test jcs_golden_bytes_match ... ok` and `test result: ok. 1 passed; 0 failed`.
+
+  If the assertion fails (hand-computed canonical doesn't match `serde_jcs` output), inspect:
+  ```bash
+  cargo test -p nixfleet-canonicalize --test jcs_golden -- --nocapture 2>&1 | sed -n '/JCS output drifted/,/^$/p'
+  ```
+  Then either fix the fixture OR file an upstream bug on `serde_jcs` — DO NOT change the lib to paper over.
+
+- [ ] **Step 3.** Commit.
+
+  ```bash
+  git add crates/nixfleet-canonicalize/src/lib.rs
+  git commit -m "feat(canonicalize): implement canonicalize() over serde_jcs"
+  ```
+
+---
+
+## Task 4 — Idempotence test
+
+Canonical form must be a fixed point: `canonicalize(canonicalize(x)) == canonicalize(x)`.
+
+**Files.** Modify `crates/nixfleet-canonicalize/tests/jcs_golden.rs`.
+
+- [ ] **Step 1.** Append the test.
+
+  Append to the end of `tests/jcs_golden.rs`:
+  ```rust
+
+  #[test]
+  fn canonicalize_is_idempotent() {
+      let once = canonicalize(GOLDEN_INPUT).expect("canonicalize once");
+      let twice = canonicalize(&once).expect("canonicalize canonical form");
+      assert_eq!(once, twice, "canonical form must be a fixed point");
+  }
+  ```
+
+- [ ] **Step 2.** Verify — should pass immediately (the property already holds).
+
+  Run: `cargo test -p nixfleet-canonicalize --test jcs_golden 2>&1 | tail -10`
+  Expected: `test result: ok. 2 passed; 0 failed`.
+
+  If it fails, there is a bug in `serde_jcs`' re-canonicalization — file upstream; do not suppress.
+
+- [ ] **Step 3.** Commit.
+
+  ```bash
+  git add crates/nixfleet-canonicalize/tests/jcs_golden.rs
+  git commit -m "test(canonicalize): lock in idempotence of canonical form"
+  ```
+
+---
+
+## Task 5 — Reorder-invariance test
+
+Two inputs differing only in key order must canonicalize identically.
+
+**Files.** Modify `crates/nixfleet-canonicalize/tests/jcs_golden.rs`.
+
+- [ ] **Step 1.** Append the test.
+
+  ```rust
+
+  #[test]
+  fn reordering_input_does_not_change_canonical_output() {
+      let reordered = r#"{"schemaVersion":1,"a":{"x":[3,1,2],"z":null,"y":true},"b":2}"#;
+      let original = canonicalize(GOLDEN_INPUT).expect("canonicalize original");
+      let shuffled = canonicalize(reordered).expect("canonicalize shuffled");
+      assert_eq!(
+          original, shuffled,
+          "canonical output must be invariant under input key ordering"
+      );
+  }
+  ```
+
+- [ ] **Step 2.** Verify.
+
+  Run: `cargo test -p nixfleet-canonicalize --test jcs_golden 2>&1 | tail -10`
+  Expected: `test result: ok. 3 passed; 0 failed`.
+
+- [ ] **Step 3.** Commit.
+
+  ```bash
+  git add crates/nixfleet-canonicalize/tests/jcs_golden.rs
+  git commit -m "test(canonicalize): assert key-order invariance"
+  ```
+
+---
+
+## Task 6 — Invalid-JSON rejection test
+
+**Files.** Modify `crates/nixfleet-canonicalize/tests/jcs_golden.rs`.
+
+- [ ] **Step 1.** Append the test.
+
+  ```rust
+
+  #[test]
+  fn invalid_json_is_rejected() {
+      let result = canonicalize("{not json");
+      assert!(result.is_err(), "invalid JSON must be rejected");
+  }
+  ```
+
+- [ ] **Step 2.** Verify.
+
+  Run: `cargo test -p nixfleet-canonicalize --test jcs_golden 2>&1 | tail -10`
+  Expected: `test result: ok. 4 passed; 0 failed`.
+
+- [ ] **Step 3.** Commit.
+
+  ```bash
+  git add crates/nixfleet-canonicalize/tests/jcs_golden.rs
+  git commit -m "test(canonicalize): reject invalid JSON input"
+  ```
+
+---
+
+## Task 7 — REFACTOR: binary stdin/stdout wrapper
+
+**Files.** Overwrite the placeholder `crates/nixfleet-canonicalize/src/main.rs` (created in Task 1) with the real implementation.
+
+- [ ] **Step 1.** Replace the placeholder with the real wrapper.
+
+  File: `crates/nixfleet-canonicalize/src/main.rs` (full replacement)
+  ```rust
+  //! `nixfleet-canonicalize` — stdin JSON → JCS canonical stdout.
+  //!
+  //! Shell-invocable canonicalizer for Stream A's CI signing
+  //! pipeline. Exit codes:
+  //! - 0 — canonical bytes written to stdout
+  //! - 1 — input was not valid JSON or canonicalization failed
+  //! - 2 — I/O error reading stdin or writing stdout
+
+  use std::io::{self, Read, Write};
+  use std::process::ExitCode;
+
+  fn main() -> ExitCode {
+      let mut input = String::new();
+      if let Err(err) = io::stdin().read_to_string(&mut input) {
+          eprintln!("nixfleet-canonicalize: read stdin: {err}");
+          return ExitCode::from(2);
+      }
+
+      let canonical = match nixfleet_canonicalize::canonicalize(&input) {
+          Ok(s) => s,
+          Err(err) => {
+              eprintln!("nixfleet-canonicalize: {err:#}");
+              return ExitCode::from(1);
+          }
+      };
+
+      let mut stdout = io::stdout().lock();
+      if let Err(err) = stdout.write_all(canonical.as_bytes()) {
+          eprintln!("nixfleet-canonicalize: write stdout: {err}");
+          return ExitCode::from(2);
+      }
+
+      ExitCode::SUCCESS
+  }
+  ```
+
+- [ ] **Step 2.** Verify the binary builds.
+
+  Run: `cargo build -p nixfleet-canonicalize --bin nixfleet-canonicalize 2>&1 | tail -5`
+  Expected: `Finished` (no errors).
+
+- [ ] **Step 3.** Shell round-trip smoke.
+
+  Run: `echo '{"b":1,"a":2}' | cargo run -q -p nixfleet-canonicalize`
+  Expected stdout (no trailing newline):
+  ```
+  {"a":2,"b":1}
+  ```
+
+  Verify exit code:
+  Run: `echo '{"b":1,"a":2}' | cargo run -q -p nixfleet-canonicalize; echo "exit=$?"`
+  Expected: `{"a":2,"b":1}exit=0` (output and exit=0 on the same or next line depending on trailing-newline rendering).
+
+- [ ] **Step 4.** Commit.
+
+  ```bash
+  git add crates/nixfleet-canonicalize/src/main.rs
+  git commit -m "feat(canonicalize): add stdin/stdout binary wrapper"
+  ```
+
+---
+
+## Task 8 — Contract amendment (`docs/CONTRACTS.md §III`)
+
+Load-bearing contract change. Per §VII any further pin move needs signoff from every stream that signs/verifies.
+
+**Files.** Modify `docs/CONTRACTS.md`.
+
+- [ ] **Step 1.** Replace the §III bullet block.
+
+  Find exactly this block inside §III:
+  ```markdown
+  - **Library choice.** TBD — Stream C's first commit must pin one (`serde_jcs` or equivalent) and document it here. Requirements: RFC 8785 conformant, handles all JSON edge cases (Unicode NFC, number precision, key sorting on non-ASCII).
+  - **Golden-file test.** `tests/fixtures/jcs-golden.json` → `tests/fixtures/jcs-golden.canonical` → known ed25519 signature. Test runs on every CI and fails any subtle drift.
+  - **Usage.** Every signed artifact (fleet.resolved, probe output) is canonicalized via this single library before signing and before verification. No ad-hoc serializers.
+  ```
+
+  Replace with:
+  ```markdown
+  - **Library choice.** Pinned to [`serde_jcs`](https://crates.io/crates/serde_jcs) `0.2`, hosted by `crates/nixfleet-canonicalize`. Rationale: direct RFC 8785 implementation over `serde_json::Value`; handles UTF-16 key sorting and ECMAScript number formatting per spec. Any change to this pin is a contract change (§VII) requiring signoff from every stream that signs or verifies artifacts (A, B, C).
+  - **Golden-file test.** `crates/nixfleet-canonicalize/tests/fixtures/jcs-golden.{json,canonical}` with byte-exact equality asserted in `tests/jcs_golden.rs`. Runs on every push via pre-push `cargo nextest run --workspace`; fails loudly on any drift. The ed25519-signed-bytes extension of this fixture lands alongside the CI release key.
+  - **Usage.** Every signed artifact (fleet.resolved, probe output) is canonicalized via this single library before signing and before verification. No ad-hoc serializers in Nix, shell, or other crates.
+  ```
+
+- [ ] **Step 2.** Verify the TBD in §III is gone.
+
+  Run: `awk '/^## III\./,/^## IV\./' docs/CONTRACTS.md | grep -c TBD`
+  Expected: `0`
+
+  Run: `grep -n "serde_jcs" docs/CONTRACTS.md`
+  Expected: one match inside §III citing version `0.2`.
+
+- [ ] **Step 3.** Commit.
+
+  ```bash
+  git add docs/CONTRACTS.md
+  git commit -m "docs(contracts): pin JCS library to serde_jcs 0.2 (§III)"
+  ```
+
+---
+
+## Task 9 — Deferred workspace-deps hygiene → PR description
+
+`TODO.md` was removed from tracking in an earlier OSS-polish commit and is listed in `.gitignore`. Reintroducing a tracked `TODO.md` reverses that prior decision and is out of scope here. Instead, the deferred work is captured in the PR description at ship time.
+
+- [ ] **Step 1.** No repository edit. Carry the deferred note into the PR body at ship time:
+
+  > **Deferred.** Migrate shared crate dependencies (serde, serde_json, chrono, anyhow, tracing) to `[workspace.dependencies]` so versions are pinned in one place. Not in scope for this kickoff PR; natural home is the Phase 4 trim pass.
+
+No commit for this task.
+
+---
+
+## Task 10 — Pre-commit conformance
+
+Ensure treefmt normalization is clean before the pre-push gauntlet.
+
+- [ ] **Step 1.** Run project formatter.
+
+  **[USER RUNS]**: `nix fmt -- --no-cache`
+  Expected: no files changed (exits cleanly).
+
+- [ ] **Step 2.** Run the `--fail-on-change` variant the pre-commit hook uses.
+
+  **[USER RUNS]**: `nix fmt -- --no-cache --fail-on-change`
+  Expected: exit 0.
+
+- [ ] **Step 3.** If Step 1 reformatted any files, commit the normalization; otherwise skip.
+
+  ```bash
+  git status
+  # If dirty:
+  git add -A
+  git commit -m "chore(fmt): treefmt normalization"
+  ```
+
+---
+
+## Task 11 — Pre-push gauntlet simulation (workspace)
+
+Proves the new crate does not break any existing crate, and the eval side still evaluates.
+
+- [ ] **Step 1.** Workspace test gauntlet.
+
+  **[USER RUNS]**: `nix develop --command cargo nextest run --workspace 2>&1 | tail -40`
+  Expected: last line resembles `Summary [N.Ns] X tests run: X passed (N skipped), 0 failed`. Zero failures required.
+
+  If a pre-existing crate fails for unrelated reasons, flag it to the user and stop — do NOT suppress.
+
+- [ ] **Step 2.** Nix eval checks (other half of pre-push hook).
+
+  **[USER RUNS]**:
+  ```bash
+  for check in eval-hostspec-defaults eval-ssh-hardening eval-username-override eval-locale-timezone eval-ssh-authorized eval-password-files; do
+    nix build ".#checks.x86_64-linux.$check" --no-link || { echo "FAILED: $check"; break; }
+  done
+  ```
+  Expected: no `FAILED:` output. These live in Stream B territory — failures block push but are unrelated to Stream C code.
+
+No commit — verification only.
+
+---
+
+## Ship checkpoint
+
+After Tasks 0–11 all green on the user's machine:
+
+- [ ] **Step 1.** Show what will be pushed.
+
+  ```bash
+  git -c core.pager=cat log --oneline main..HEAD
+  git -c core.pager=cat diff --stat main..HEAD
+  ```
+
+- [ ] **Step 2.** Present to user. Exact wording:
+
+  > Branch `feat/12-canonicalize-jcs-pin` ready. N commits ahead of main; diff-stat above. User gauntlet green. Push to `origin` and open PR on `abstracts33d/nixfleet`?
+
+  **Do NOT push, do NOT open PR, do NOT merge without explicit user confirmation.**
+
+- [ ] **Step 3.** When — and only when — the user says ship, push and open PR:
+
+  ```bash
+  git push -u origin feat/12-canonicalize-jcs-pin
+  gh pr create --repo abstracts33d/nixfleet --base main \
+    --title "feat(canonicalize): pin JCS library and ship nixfleet-canonicalize (#12)" \
+    --body "$(cat <<'EOF'
+  ## Summary
+  - New crate `crates/nixfleet-canonicalize`: lib + thin binary, JCS (RFC 8785) canonicalizer pinned to `serde_jcs = "0.2"`.
+  - `docs/CONTRACTS.md §III` amended to record the pin — load-bearing contract change per §VII.
+  - Golden fixture + four tests (byte-exact match, idempotence, reorder invariance, invalid-JSON rejection).
+  - `TODO.md` flags the deferred `[workspace.dependencies]` hygiene pass.
+
+  Partial close of #12 (Rust portion: canonicalize tool). Signature-verification code lands alongside the CI release key handoff from Stream A.
+
+  ## Test plan
+  - [x] `cargo test -p nixfleet-canonicalize` green (4 tests).
+  - [x] `cargo nextest run --workspace` green (pre-push gate simulated locally).
+  - [x] `nix fmt -- --no-cache --fail-on-change` clean.
+  - [x] Shell round-trip: `echo '{"b":1,"a":2}' | nixfleet-canonicalize` prints `{"a":2,"b":1}` with no trailing newline.
+  - [ ] Reviewer: re-run the workspace test gauntlet locally.
+
+  ## Contract change
+  `docs/CONTRACTS.md §III` is amended to pin the JCS library. Per §VII this requires signoff from every stream that signs or verifies. Streams A (CI signer) and B (Nix eval → pre-sign canonicalize) consume the pin; both streams are tagged for review.
+  EOF
+  )"
+  ```
+
+---
+
+## Self-review
+
+- [x] Spec Goal #1 (pin JCS) → Task 1 + Task 8.
+- [x] Spec Goal #2 (ship crate with lib + bin) → Tasks 1, 3, 7.
+- [x] Spec Goal #3 (lock pin in §III) → Task 8.
+- [x] Spec Goal #4 (byte-exact golden test) → Tasks 2–6.
+- [x] Every Non-Goal in spec is NOT a task here (no proto, no workspace-deps, no RFC 8785 vectors, no `lib/`/`modules/`/`spike/` touches, no signature verification).
+- [x] Test Strategy ordering (RED golden → GREEN lib → idempotence → reorder → invalid → REFACTOR bin → LAST contract edit) is the literal order of Tasks 2–8.
+- [x] Both Open Questions are preserved as deferrals, not silently resolved.
+- [x] No `TBD`, `later`, or "similar to task N" placeholders.
+- [x] Every `Run:` step has expected output.
+- [x] Heavy commands (`cargo nextest run --workspace`, `nix fmt`, `nix build`, `nix develop`) are tagged **[USER RUNS]**; cheap per-crate commands are not.
+- [x] Branch rename is a pre-flight task before any file changes.
+- [x] Ship checkpoint is explicit: no push, no PR without user approval.

--- a/docs/superpowers/specs/feat-12-canonicalize-jcs-pin.md
+++ b/docs/superpowers/specs/feat-12-canonicalize-jcs-pin.md
@@ -1,0 +1,97 @@
+# feat/12-canonicalize-jcs-pin — Design Spec
+
+**Date:** 2026-04-24
+**Status:** Draft
+**Issue:** abstracts33d/nixfleet#12 (Rust portion — canonicalize tool only)
+**Branch:** `feat/12-canonicalize-jcs-pin` (rename from `feat/12-canonicalize-proto`)
+**Worktree:** `.worktrees/stream-c`
+**Stream:** C (Rust). Parallel: Stream B lives in `.worktrees/mkfleet-promotion`.
+
+## Goals
+
+- Pin the JCS (RFC 8785) library for the whole v0.2 fleet to `serde_jcs = "0.2"`.
+- Ship a new `crates/nixfleet-canonicalize/` crate exposing `pub fn canonicalize(input: &str) -> Result<String, anyhow::Error>` and a thin `stdin → canonicalize → stdout` binary, shell-invocable by Stream A's CI.
+- Lock the pin in `docs/CONTRACTS.md §III` so every future signer (Stream A CI) and verifier (Stream C reconciler + agent fallback) produces byte-identical canonical bytes.
+- Prove byte-exactness with a golden-file test committed alongside the lib.
+
+## Non-Goals
+
+- **No `nixfleet-proto` crate.** Types without their first consumer cannot be validated. Proto lands with the reconciler in `feat/3-reconciler-proto`. The canonicalize tool operates on untyped `serde_json::Value` and does not need proto types.
+- **No `[workspace.dependencies]` refactor.** Existing v0.1 crates declare per-crate deps; the new crate follows that convention. A workspace-hygiene pass is deferred to Phase 4 trim; a one-line entry will be added to `TODO.md`.
+- **No RFC 8785 Appendix E vectors.** Unicode/number/escape edge-case corpus is a follow-up test-only PR, not blocking this one.
+- **No touching `lib/`, `modules/`, `spike/`, `crates/agent`, `crates/cli`, `crates/control-plane`, `crates/shared`.** Stream B is live in some of those directories.
+- **No signature verification code.** That lands with the reconciler.
+
+## Approach
+
+1. **Single crate, lib + thin bin.** `crates/nixfleet-canonicalize/` with `src/lib.rs` (the function) and `src/main.rs` (the wrapper). Follows the agent/cli layout.
+2. **JCS library pinned to `serde_jcs = "0.2"`.** Verified on crates.io: latest stable 0.2.0, exposes `to_string` / `to_vec` / `to_writer` over any `Serialize`, including `serde_json::Value`.
+3. **API.** `pub fn canonicalize(input: &str) -> anyhow::Result<String>` — parses the input as `serde_json::Value`, re-emits via `serde_jcs::to_string`. Input-level JSON errors surface as `anyhow::Error` with context.
+4. **Binary.** `src/main.rs` reads all of stdin, calls `canonicalize`, writes result to stdout with no trailing newline. Exit code 1 on any error, with the message on stderr.
+5. **Conventions.** `edition = "2021"`, `license = "MIT"`, `authors = ["nixfleet contributors"]`, matching existing crates. Deps: `serde_jcs = "0.2"`, `serde_json = "1"`, `anyhow = "1"`. Dev-deps: none required for milestone 1.
+6. **Contract amendment.** `docs/CONTRACTS.md §III` TBD block is replaced with: library pin (`serde_jcs 0.2`), rationale, golden-fixture path, and an explicit note that changing the pin is a `contract-change` PR per §VII.
+7. **Strict TDD.** Tests land before code per `superpowers:test-driven-development`. See Test Strategy.
+
+## API / Interface
+
+```rust
+// crates/nixfleet-canonicalize/src/lib.rs
+pub fn canonicalize(input: &str) -> anyhow::Result<String>;
+```
+
+Binary (`nixfleet-canonicalize`): reads stdin to EOF, writes canonical JSON to stdout without trailing newline, non-zero exit on error.
+
+Golden fixture (the one hand-verifiable case this PR commits):
+
+- Input (`tests/fixtures/jcs-golden.json`):
+  `{"b":2,"a":{"z":null,"y":true,"x":[3,1,2]},"schemaVersion":1}`
+- Expected canonical (`tests/fixtures/jcs-golden.canonical`, 61 bytes, no trailing newline):
+  `{"a":{"x":[3,1,2],"y":true,"z":null},"b":2,"schemaVersion":1}`
+
+Properties covered by the fixture: top-level key sort, nested key sort, array order preservation (NOT sorted), `null`/`true`/integer literals.
+
+## Edge Cases
+
+- **Invalid JSON input.** `canonicalize("not json")` returns `Err`. Binary prints the error to stderr and exits non-zero.
+- **Empty string.** Treated as invalid JSON. Same as above.
+- **Trailing newline on input.** `serde_json::from_str` accepts trailing whitespace; output still has no trailing newline.
+- **Nested null / boolean / integer literals.** Covered by the golden fixture.
+- **Deeply nested / large / Unicode-heavy payloads.** Not exercised in this PR; deferred to the follow-up RFC 8785 Appendix E corpus (see Open Questions).
+
+## Test Strategy
+
+All tests live in `tests/jcs_golden.rs`; fixtures under `tests/fixtures/`. Red-green-refactor, in this order:
+
+1. **RED — golden.** Write `tests/jcs_golden.rs` with `fn golden()` asserting `canonicalize(include_str!("fixtures/jcs-golden.json"))? == include_str!("fixtures/jcs-golden.canonical")`. `canonicalize` does not yet exist → compile error.
+2. **GREEN — lib.** Write `src/lib.rs` delegating to `serde_jcs::to_string(&serde_json::from_str::<serde_json::Value>(input)?)`. Golden test passes.
+3. **RED — idempotence.** Add `fn idempotent()`: `canonicalize(&canonicalize(x)?)? == canonicalize(x)?`. Should already pass; the test locks in the property.
+4. **RED — reorder invariance.** Add `fn reorder_invariance()`: two inputs whose keys are permuted produce identical canonical output.
+5. **RED — invalid JSON rejection.** Add `fn rejects_invalid()`: `canonicalize("{").is_err()`.
+6. **REFACTOR — binary.** Write `src/main.rs` reading stdin and emitting to stdout. No dedicated binary test in this PR (shell-level smoke tests are Stream A's concern on integration).
+7. **LAST — contract pin.** Only after all four tests are green, update `docs/CONTRACTS.md §III` to replace TBD with the working pin.
+
+Acceptance criteria for the PR:
+- `cargo test -p nixfleet-canonicalize` green (user-run).
+- `cargo nextest run --workspace` (pre-push gate) green — the new crate compiles standalone without touching existing crates.
+- `docs/CONTRACTS.md §III` no longer contains "TBD".
+
+**Build economy.** The implementing agent MUST NOT run `cargo test --workspace`, `cargo nextest run --workspace`, `nix build`, or `nix flake check`. Per-crate commands (`cargo fmt -p nixfleet-canonicalize`, `cargo test -p nixfleet-canonicalize`) are handed to the user as copy-paste blocks.
+
+## Files
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `crates/nixfleet-canonicalize/Cargo.toml` | create | Crate manifest, pinned deps |
+| `crates/nixfleet-canonicalize/src/lib.rs` | create | `pub fn canonicalize` |
+| `crates/nixfleet-canonicalize/src/main.rs` | create | stdin→stdout wrapper |
+| `crates/nixfleet-canonicalize/tests/jcs_golden.rs` | create | Golden + idempotence + reorder + invalid tests |
+| `crates/nixfleet-canonicalize/tests/fixtures/jcs-golden.json` | create | Input fixture |
+| `crates/nixfleet-canonicalize/tests/fixtures/jcs-golden.canonical` | create | Expected output (61 bytes, no trailing newline) |
+| `docs/CONTRACTS.md` | edit | §III: replace TBD with pinned `serde_jcs 0.2` + rationale + §VII note |
+| `Cargo.lock` | auto | Regenerated by cargo on first build |
+| `TODO.md` | edit (append one line) | Flag deferred workspace-deps hygiene pass |
+
+## Open Questions
+
+1. **Option-field null-vs-skip posture for `fleet.resolved`.** Whether `Option<T>::None` fields serialize as `null` or are skipped affects canonical bytes. This is a reconciler-crate decision (types and their serde attributes live with `nixfleet-proto` in `feat/3-reconciler-proto`); the canonicalize tool is untyped and unaffected. Deferred to that PR.
+2. **RFC 8785 Appendix E conformance corpus.** A dedicated test-only follow-up PR will add Unicode normalization, float-edge, and escape vectors from the RFC. Not blocking milestone 1.


### PR DESCRIPTION
## Summary
- New crate `crates/nixfleet-canonicalize`: lib + thin stdin/stdout binary; JCS (RFC 8785) canonicalizer pinned to `serde_jcs = "0.2"`.
- `docs/CONTRACTS.md §III` amended to record the pin — load-bearing contract change per §VII.
- Golden fixture + 4 tests (byte-exact golden, idempotence, reorder invariance, invalid JSON rejection).
- Spec and plan tracked under `docs/superpowers/`.

Closes part of #12 (Rust portion: canonicalize tool). Signature-verification code lands alongside the CI release key handoff from Stream A.

## Test plan
- [x] `cargo test -p nixfleet-canonicalize` → 4 passed.
- [x] Pre-push gauntlet green: `cargo nextest run --workspace` → 372 passed, 0 failed; `nix fmt --no-cache --fail-on-change` clean; eval checks green.
- [x] Shell round-trip: `echo '{"b":1,"a":2}' | nixfleet-canonicalize` prints `{"a":2,"b":1}` with no trailing newline, exit 0.
- [x] Invalid JSON exits 1 with a context-chain error; stdin/stdout I/O errors exit 2.
- [ ] Reviewer: re-run `cargo nextest run --workspace` locally.

## Contract change
`docs/CONTRACTS.md §III` is amended to pin the JCS library. Per §VII this requires signoff from every stream that signs or verifies. Streams A (CI signer) and B (Nix eval → pre-sign canonicalize) consume the pin.

## Deferred
- `[workspace.dependencies]` migration for shared deps (serde, serde_json, chrono, anyhow, tracing). Natural home: trim pass.
- RFC 8785 Appendix E conformance corpus — test-only follow-up PR.
- `nixfleet-proto` serde types for `docs/CONTRACTS.md §I` artifacts — lands with the reconciler PR.
- Signature verification in the reconciler — follow-up alongside the CI release key handoff.
- Pre-existing defect at `docs/CONTRACTS.md:27` (says "see §IV" but should say "see §III") — one-line follow-up.