### PR TITLE
feat: promote mkFleet + nixfleet.trust.* option tree (#1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ## [Unreleased]
 
+### Added
+
+- `lib.mkFleet` — evaluates a declarative fleet description per RFC-0001 and emits a typed `.resolved` artifact. Every invariant from §4.2 is enforced at eval time: host/channel/policy references, host `configuration` validity, edge DAG, compliance-framework allow-list, and the cross-field `freshnessWindow ≥ 2 × signingIntervalMinutes` relation.
+- `lib.withSignature` — helper that CI calls to stamp `meta.signedAt` / `meta.ciCommit` onto a resolved fleet before signing.
+- `nixfleet.trust.*` option tree in `modules/_trust.nix` — declares CI release key, attic cache key, and org root key (with rotation grace slots and a compromise `rejectBefore` switch) per `docs/CONTRACTS.md §II`.
+- `examples/fleet-homelab/` — working end-to-end example producing a signed-shape `fleet.resolved`.
+- `tests/lib/mkFleet/` — eval-only harness with positive fixtures (golden JSON comparison), negative fixtures (expected-failure via `tryEval`), and `_`-prefix filter for shared helpers.
+
+### Changed
+
+- New channel options: `signingIntervalMinutes` (default 60) and `freshnessWindow` (no default — must declare). Existing channel definitions must add these to evaluate.
+- New host option: `pubkey` (nullable, OpenSSH-format ed25519). Host entries may still omit it; enrollment-bound hosts MUST set it.
+- `fleet.resolved` shape extended with a `meta` attribute (`{schemaVersion, signedAt, ciCommit}`) per `docs/CONTRACTS.md §I #1`. Top-level `schemaVersion: 1` is preserved for RFC-0001 §4.1 backward reference.
+
 ## [0.1.0] - 2026-04-19
 
 Initial release.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Dynamic tab completion for rollout/release/machine IDs, queried live from the co
 | `examples/standalone-host/` | Single machine in its own repo |
 | `examples/batch-hosts/` | 50+ identical machines from a template |
 | `examples/client-fleet/` | Multi-host fleet with flake-parts |
+| `examples/fleet-homelab/` | Declarative fleet via `lib.mkFleet` — run `nix eval .#fleet.resolved --json` to inspect the resolved artifact |
 | `examples/securix-endpoint/` | Hardened ANSSI BP-028 distro composition with Securix |
 
 ## Documentation

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -158,6 +158,8 @@ Four keys. Everything else is derived. For each: **who holds the private key, wh
 
 **JCS (RFC 8785) with a single Rust implementation, byte-identical across all signers and verifiers.**
 
+Producer-side (Stream B's `lib/mkFleet.nix`) MUST emit values that round-trip through JCS losslessly: ints only (no floats), deterministic attr order, no JSON-incompatible types. Consumer-side (Stream C's `bin/nixfleet-canonicalize`) pins the library.
+
 - **Library choice.** TBD — Stream C's first commit must pin one (`serde_jcs` or equivalent) and document it here. Requirements: RFC 8785 conformant, handles all JSON edge cases (Unicode NFC, number precision, key sorting on non-ASCII).
 - **Golden-file test.** `tests/fixtures/jcs-golden.json` → `tests/fixtures/jcs-golden.canonical` → known ed25519 signature. Test runs on every CI and fails any subtle drift.
 - **Usage.** Every signed artifact (fleet.resolved, probe output) is canonicalized via this single library before signing and before verification. No ad-hoc serializers.

--- a/docs/superpowers/plans/2026-04-24-mkfleet-promotion.md
+++ b/docs/superpowers/plans/2026-04-24-mkfleet-promotion.md
@@ -1,0 +1,1456 @@
+# mkFleet promotion + nixfleet.trust.* Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Promote the `spike/lib/mkFleet.nix` prototype to production `lib/mkFleet.nix` with every RFC-0001 §4.2 invariant implemented, add the `nixfleet.trust.*` option tree, and wire a `fleet` flake output that produces a CONTRACTS §I.1-compliant `fleet.resolved` artifact.
+
+**Architecture:** Library-style Nix module evaluator. `lib.mkFleet { ... }` evaluates the fleet description through `lib.evalModules`, fails fast on any invariant violation (strict typing + a DAG check + a freshness-window relation check), and exposes a `resolved` attribute that is the CI-consumable projection defined in RFC-0001 §4.1 and CONTRACTS §I.1. Trust roots live in a sibling `modules/trust.nix` NixOS module exposing `nixfleet.trust.{ciReleaseKey,atticCacheKey,orgRootKey}` option trees, each with a `.previous` grace-window slot and a shared `rejectBefore` compromise switch.
+
+**Tech Stack:** Nix, flake-parts, `lib.evalModules`, JCS-shaped JSON output (actual signing tooling lives in Stream C, but the shape and fields land here).
+
+**Issues closed:** abstracts33d/nixfleet#1, Nix portion of abstracts33d/nixfleet#12.
+
+---
+
+## File Structure
+
+### Created
+
+| Path | Responsibility |
+|---|---|
+| `lib/mkFleet.nix` | Production mkFleet implementation. Evaluates module, checks invariants, emits `.resolved`. |
+| `lib/flake-module.nix` | flake-parts wiring so `config.flake.lib.mkFleet` is exposed to consumers. |
+| `modules/trust.nix` | `nixfleet.trust.*` option tree (pubkey declarations, grace windows, compromise switch). |
+| `examples/fleet-homelab/flake.nix` | Minimal end-to-end example invoking `mkFleet` against stub nixosConfigurations, used as acceptance artifact. |
+| `examples/fleet-homelab/fleet.nix` | The declarative fleet description fed into `mkFleet`. |
+| `examples/fleet-homelab/hosts/*.nix` | Stub host modules (copied from `spike/examples/homelab/hosts/`, trimmed to minimum). |
+| `tests/lib/mkFleet/fleet-resolved-golden.nix` | Eval-time assertion: homelab example `.resolved` equals a pinned JSON fixture. |
+| `tests/lib/mkFleet/negative/*.nix` | One fixture per invariant, each expected to fail `nix eval`. |
+| `tests/lib/mkFleet/fixtures/homelab.resolved.json` | Pinned expected JSON artifact for the homelab example. |
+| `modules/tests/trust-options.nix` | Eval test for `nixfleet.trust.*` option types. |
+| `CHANGELOG.md` entry | User-visible note about the new `fleet` flake output and `nixfleet.trust.*` options. |
+
+### Modified
+
+| Path | Change |
+|---|---|
+| `modules/flake-module.nix` | Import `lib/flake-module.nix` so `config.flake.lib.mkFleet` is wired into the plugin framework. |
+| `modules/core/_nixos.nix` (or the file that re-exports modules) | Import `modules/trust.nix` so `nixfleet.trust.*` options are available on every host. |
+| `flake.nix` | If needed, expose `lib.mkFleet` at the top level for external flakes. |
+
+### Not touched in this plan
+
+- `spike/` — leave intact; the spike stays as the runnable prototype. We promote, we do not delete.
+- `crates/` — Rust consumers are Stream C's concern.
+- Any existing `modules/fleet.nix` — that is the test fleet fixture, unrelated to this artifact.
+
+---
+
+## Pre-flight
+
+The worktree for this work is `.worktrees/mkfleet-promotion` on branch `feat/mkfleet-promotion` (already created off `main`). All commands below run from the worktree root unless stated otherwise.
+
+**User-run commands (build economy):** Every `nix eval`, `nix flake check`, and `nix build` below is listed so the operator can run it — do not auto-run heavy commands. The agent may run `nix eval --raw` on tiny fixtures that return plain strings; anything that builds a derivation is user-side.
+
+---
+
+## Task 1: Scaffold `lib/` and the promoted mkFleet
+
+**Files:**
+- Create: `lib/mkFleet.nix`
+- Create: `lib/flake-module.nix`
+- Create: `lib/default.nix`
+- Modify: `modules/flake-module.nix:1-72`
+
+- [ ] **Step 1: Create `lib/default.nix`**
+
+```nix
+# lib/default.nix
+#
+# nixfleet library entry point. Imports are keyed by capability so consumers
+# can depend on narrow slices (e.g. just `mkFleet`) without pulling the full
+# framework module graph.
+{lib}: {
+  mkFleet = (import ./mkFleet.nix {inherit lib;}).mkFleet;
+}
+```
+
+- [ ] **Step 2: Copy the spike as the starting point**
+
+Run:
+
+```bash
+cp spike/lib/mkFleet.nix lib/mkFleet.nix
+```
+
+Do not modify the file yet — subsequent tasks extend it invariant-by-invariant so each commit is atomic and bisectable.
+
+- [ ] **Step 3: Create `lib/flake-module.nix`**
+
+```nix
+# lib/flake-module.nix
+#
+# Exposes `config.flake.lib.mkFleet` via flake-parts so consumers can call
+# `nixfleet.lib.mkFleet { ... }` from their own flakes.
+{lib, ...}: {
+  config.flake.lib.mkFleet =
+    (import ./mkFleet.nix {inherit lib;}).mkFleet;
+}
+```
+
+- [ ] **Step 4: Wire the new flake-module into the framework export**
+
+In `modules/flake-module.nix`, add `../lib/flake-module.nix` to the imports list of the top-level flake-parts module. Open the file and locate the `config.flake = { ... }` block. Add an `imports` clause at the top level of the module body:
+
+```nix
+{
+  inputs,
+  lib,
+  ...
+}: let
+  nixfleetLib = import ./_shared/lib/default.nix {inherit inputs lib;};
+in {
+  imports = [../lib/flake-module.nix];
+
+  options.nixfleet.lib = lib.mkOption {
+    # ...unchanged
+  };
+  # ...rest of file unchanged
+}
+```
+
+- [ ] **Step 5: Sanity check — evaluate the exported lib**
+
+User runs:
+
+```bash
+nix eval --impure --expr 'builtins.typeOf (import ./lib/default.nix { lib = (builtins.getFlake (toString ./.)).inputs.nixpkgs.lib; }).mkFleet'
+```
+
+Expected output: `"lambda"`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/ modules/flake-module.nix
+git commit -m "feat(lib): scaffold mkFleet promotion from spike"
+```
+
+---
+
+## Task 2: Add fixture-based eval harness
+
+**Files:**
+- Create: `tests/lib/mkFleet/default.nix`
+- Create: `tests/lib/mkFleet/fixtures/.gitkeep`
+- Create: `tests/lib/mkFleet/negative/.gitkeep`
+- Modify: `modules/tests/eval.nix` (if present) — else `modules/tests/default.nix`
+
+- [ ] **Step 1: Locate the existing eval-tests entry point**
+
+Run:
+
+```bash
+grep -rn "eval" modules/tests/ 2>/dev/null | head -20
+```
+
+Note the file that assembles per-scenario eval tests. The existing convention is one test per subdirectory.
+
+- [ ] **Step 2: Create the harness entry point**
+
+```nix
+# tests/lib/mkFleet/default.nix
+#
+# Eval-only tests for lib/mkFleet.nix. No VM, no build — pure evaluation.
+# Each .nix file under ./fixtures/ is a positive scenario (must eval clean).
+# Each .nix file under ./negative/ is expected to `throw` a specific error.
+{
+  lib,
+  mkFleet ? (import ../../../lib/mkFleet.nix {inherit lib;}).mkFleet,
+}: let
+  runPositive = path: let
+    cfg = import path {inherit lib mkFleet;};
+    expectedPath = lib.replaceStrings [".nix"] [".resolved.json"] path;
+    expected = builtins.fromJSON (builtins.readFile expectedPath);
+    actual = cfg.resolved;
+    match = builtins.toJSON actual == builtins.toJSON expected;
+  in
+    if match
+    then "ok"
+    else throw ''
+      golden mismatch for ${toString path}
+      expected: ${builtins.toJSON expected}
+      actual:   ${builtins.toJSON actual}
+    '';
+
+  runNegative = path: let
+    result = builtins.tryEval (import path {inherit lib mkFleet;}).resolved;
+  in
+    if result.success
+    then throw "expected eval failure for ${toString path}, got success"
+    else "ok";
+
+  listFixtures = dir:
+    lib.filter (n: lib.hasSuffix ".nix" n) (builtins.attrNames (builtins.readDir dir));
+
+  positives = map (n: runPositive (./fixtures + "/${n}")) (listFixtures ./fixtures);
+  negatives = map (n: runNegative (./negative + "/${n}")) (listFixtures ./negative);
+in {
+  results = positives ++ negatives;
+}
+```
+
+- [ ] **Step 3: Drop-in the placeholder fixture directories**
+
+```bash
+mkdir -p tests/lib/mkFleet/fixtures tests/lib/mkFleet/negative
+touch tests/lib/mkFleet/fixtures/.gitkeep tests/lib/mkFleet/negative/.gitkeep
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/lib/mkFleet/
+git commit -m "test(lib/mkFleet): add fixture-based eval harness"
+```
+
+---
+
+## Task 3: Invariant — host `configuration` is a nixosConfiguration
+
+**Files:**
+- Modify: `lib/mkFleet.nix`
+- Create: `tests/lib/mkFleet/negative/host-bad-configuration.nix`
+
+- [ ] **Step 1: Write the failing negative fixture**
+
+```nix
+# tests/lib/mkFleet/negative/host-bad-configuration.nix
+{lib, mkFleet}:
+mkFleet {
+  hosts.bad = {
+    system = "x86_64-linux";
+    configuration = "not-a-nixos-config";
+    tags = [];
+    channel = "stable";
+  };
+  channels.stable = {
+    rolloutPolicy = "all-at-once";
+    signingIntervalMinutes = 60;
+    freshnessWindow = 180;
+  };
+  rolloutPolicies.all-at-once = {
+    strategy = "all-at-once";
+    waves = [{selector.all = true; soakMinutes = 0;}];
+  };
+}
+```
+
+- [ ] **Step 2: Run the eval test — expect negative failure (no error today)**
+
+User runs:
+
+```bash
+nix eval --impure --expr 'import ./tests/lib/mkFleet/default.nix { lib = (builtins.getFlake (toString ./.)).inputs.nixpkgs.lib; }'
+```
+
+Expected: the harness throws `expected eval failure for .../host-bad-configuration.nix, got success` — meaning the invariant check does not exist yet.
+
+- [ ] **Step 3: Extend `checkInvariants` in `lib/mkFleet.nix`**
+
+In the `checkInvariants` let-binding, after `edgeErrors`, add:
+
+```nix
+    configurationErrors =
+      lib.concatMap (
+        n: let
+          h = cfg.hosts.${n};
+          isValid =
+            builtins.isAttrs h.configuration
+            && h.configuration ? config
+            && h.configuration.config ? system
+            && h.configuration.config.system ? build
+            && h.configuration.config.system.build ? toplevel;
+        in
+          lib.optional (!isValid)
+          "host '${n}' configuration is not a valid nixosConfiguration (missing config.system.build.toplevel)"
+      )
+      hostNames;
+```
+
+Add `configurationErrors` to the `errs` sum.
+
+- [ ] **Step 4: Re-run the eval test — expect clean pass**
+
+User runs the command from Step 2. Expected: the harness evaluates to `{ results = [ "ok" ]; }` (or similar, with "ok" entries).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/mkFleet.nix tests/lib/mkFleet/negative/host-bad-configuration.nix
+git commit -m "feat(lib/mkFleet): enforce host.configuration is a nixosConfiguration"
+```
+
+---
+
+## Task 4: Invariant — empty selector warns (does not fail)
+
+**Files:**
+- Modify: `lib/mkFleet.nix`
+- Create: `tests/lib/mkFleet/fixtures/empty-selector-warns.nix`
+- Create: `tests/lib/mkFleet/fixtures/empty-selector-warns.resolved.json`
+
+RFC-0001 §4.2: "Every selector resolves to at least one host (warn, not fail — empty selectors are sometimes intentional)."
+
+- [ ] **Step 1: Add a `warnings` attribute to the module schema**
+
+In `lib/mkFleet.nix`, after the options block, change `resolveFleet` to also return `warnings`:
+
+```nix
+  resolveFleet = cfg:
+    assert checkInvariants cfg; let
+      emptySelectorWarnings =
+        lib.concatMap (
+          policyName:
+            lib.concatMap (
+              w: let
+                hosts = resolveSelector w.selector cfg.hosts;
+              in
+                lib.optional (hosts == [])
+                "rollout policy '${policyName}' has a wave with a selector that resolves to zero hosts"
+            )
+            cfg.rolloutPolicies.${policyName}.waves
+        )
+        (lib.attrNames cfg.rolloutPolicies);
+      emittedWarnings =
+        lib.foldl' (acc: msg: lib.warn msg acc) null emptySelectorWarnings;
+    in
+      builtins.seq emittedWarnings {
+        schemaVersion = 1;
+        # ... rest unchanged
+      };
+```
+
+The `lib.warn` calls print to stderr during `nix eval`; `builtins.seq` forces them so operators see the warning before downstream use.
+
+- [ ] **Step 2: Add a positive fixture asserting the resolved shape is still correct even with an empty selector**
+
+`tests/lib/mkFleet/fixtures/empty-selector-warns.nix`:
+
+```nix
+{lib, mkFleet}:
+mkFleet {
+  hosts.m = {
+    system = "x86_64-linux";
+    configuration = (import ./_stub-configuration.nix {inherit lib;});
+    tags = ["role-a"];
+    channel = "stable";
+  };
+  channels.stable = {
+    rolloutPolicy = "emptyish";
+    signingIntervalMinutes = 60;
+    freshnessWindow = 180;
+  };
+  rolloutPolicies.emptyish = {
+    strategy = "canary";
+    waves = [
+      {selector.tags = ["role-b"]; soakMinutes = 10;} # resolves to zero hosts — warning expected
+      {selector.all = true; soakMinutes = 0;}
+    ];
+  };
+}
+```
+
+- [ ] **Step 3: Create `_stub-configuration.nix` shared by fixtures**
+
+```nix
+# tests/lib/mkFleet/fixtures/_stub-configuration.nix
+#
+# Minimal stub that looks like a nixosConfiguration enough to satisfy
+# the `host.configuration` invariant without needing to evaluate NixOS.
+{lib}: {
+  config.system.build.toplevel = {
+    outPath = "/nix/store/0000000000000000000000000000000000000000-stub";
+    drvPath = "/nix/store/0000000000000000000000000000000000000000-stub.drv";
+  };
+}
+```
+
+- [ ] **Step 4: Generate the expected resolved JSON**
+
+User runs:
+
+```bash
+nix eval --impure --json --expr '(import ./tests/lib/mkFleet/fixtures/empty-selector-warns.nix { lib = (builtins.getFlake (toString ./.)).inputs.nixpkgs.lib; mkFleet = (import ./lib/mkFleet.nix { lib = (builtins.getFlake (toString ./.)).inputs.nixpkgs.lib; }).mkFleet; }).resolved' | jq . > tests/lib/mkFleet/fixtures/empty-selector-warns.resolved.json
+```
+
+Inspect the file. Confirm `waves.stable[0].hosts == []` (empty) and `waves.stable[1].hosts == ["m"]`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/mkFleet.nix tests/lib/mkFleet/fixtures/
+git commit -m "feat(lib/mkFleet): warn on empty selector resolution"
+```
+
+---
+
+## Task 5: Invariant — compliance frameworks must be declared
+
+**Files:**
+- Modify: `lib/mkFleet.nix`
+- Create: `tests/lib/mkFleet/negative/unknown-framework.nix`
+
+- [ ] **Step 1: Add an option for the declared frameworks set**
+
+At the module options in `mkFleet.nix`:
+
+```nix
+complianceFrameworks = mkOption {
+  type = types.listOf types.str;
+  default = ["anssi-bp028" "nis2" "dora" "iso27001"];
+  description = ''
+    Known compliance frameworks accepted by channel.compliance.frameworks.
+    Override only if using an out-of-tree compliance extension.
+  '';
+};
+```
+
+- [ ] **Step 2: Add the invariant check**
+
+In `checkInvariants`:
+
+```nix
+    complianceErrors =
+      lib.concatMap (
+        channelName: let
+          c = cfg.channels.${channelName};
+          bad = lib.filter (f: !(builtins.elem f cfg.complianceFrameworks)) c.compliance.frameworks;
+        in
+          map (f: "channel '${channelName}' references unknown compliance framework '${f}'") bad
+      )
+      (lib.attrNames cfg.channels);
+```
+
+Add to `errs`.
+
+- [ ] **Step 3: Write the negative fixture**
+
+```nix
+# tests/lib/mkFleet/negative/unknown-framework.nix
+{lib, mkFleet}:
+mkFleet {
+  hosts.m = {
+    system = "x86_64-linux";
+    configuration = (import ../fixtures/_stub-configuration.nix {inherit lib;});
+    tags = [];
+    channel = "stable";
+  };
+  channels.stable = {
+    rolloutPolicy = "all-at-once";
+    signingIntervalMinutes = 60;
+    freshnessWindow = 180;
+    compliance.frameworks = ["fictional-framework/v99"];
+  };
+  rolloutPolicies.all-at-once = {
+    strategy = "all-at-once";
+    waves = [{selector.all = true; soakMinutes = 0;}];
+  };
+}
+```
+
+- [ ] **Step 4: Run the harness — expect pass (negative test throws as expected)**
+
+User runs the eval command from Task 3 Step 4.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/mkFleet.nix tests/lib/mkFleet/negative/unknown-framework.nix
+git commit -m "feat(lib/mkFleet): reject unknown compliance frameworks"
+```
+
+---
+
+## Task 6: Invariant — edges form a DAG (cycle detection)
+
+**Files:**
+- Modify: `lib/mkFleet.nix`
+- Create: `tests/lib/mkFleet/negative/edge-cycle.nix`
+
+- [ ] **Step 1: Implement cycle detection**
+
+In `lib/mkFleet.nix`, above `checkInvariants`, add:
+
+```nix
+  # Tarjan-free cycle detection using iterative DFS marking.
+  # Edges: { after = "a"; before = "b"; } means a must finish before b starts.
+  # So we walk "after → before" edges.
+  hasCycle = edges: let
+    adj = lib.foldl' (
+      acc: e: let
+        current = acc.${e.after} or [];
+      in
+        acc // {${e.after} = current ++ [e.before];}
+    ) {}
+    edges;
+    nodes = lib.unique (map (e: e.after) edges ++ map (e: e.before) edges);
+    # visit returns { cycle = bool; stack = [...]; visited = [...]; }
+    visit = node: path: visited:
+      if builtins.elem node path
+      then {cycle = true; path = path ++ [node]; visited = visited;}
+      else if builtins.elem node visited
+      then {cycle = false; path = path; visited = visited;}
+      else let
+        children = adj.${node} or [];
+        walk = c: acc:
+          if acc.cycle
+          then acc
+          else let
+            r = visit c (path ++ [node]) acc.visited;
+          in
+            if r.cycle
+            then r
+            else {cycle = false; path = acc.path; visited = r.visited ++ [c];};
+        result = lib.foldl' (a: c: walk c a) {cycle = false; path = []; visited = visited;} children;
+      in
+        if result.cycle
+        then result
+        else {cycle = false; path = []; visited = result.visited ++ [node];};
+    scan = nodes:
+      lib.foldl' (
+        acc: n:
+          if acc.cycle
+          then acc
+          else visit n [] acc.visited
+      ) {cycle = false; path = []; visited = [];}
+      nodes;
+  in
+    (scan nodes).cycle;
+```
+
+Then in `checkInvariants`:
+
+```nix
+    cycleErrors = lib.optional (hasCycle cfg.edges) "edges form a cycle; the DAG invariant is violated";
+```
+
+Add `cycleErrors` to `errs`.
+
+- [ ] **Step 2: Write the negative fixture**
+
+```nix
+# tests/lib/mkFleet/negative/edge-cycle.nix
+{lib, mkFleet}:
+mkFleet {
+  hosts = {
+    a = {
+      system = "x86_64-linux";
+      configuration = (import ../fixtures/_stub-configuration.nix {inherit lib;});
+      tags = [];
+      channel = "stable";
+    };
+    b = {
+      system = "x86_64-linux";
+      configuration = (import ../fixtures/_stub-configuration.nix {inherit lib;});
+      tags = [];
+      channel = "stable";
+    };
+  };
+  channels.stable = {
+    rolloutPolicy = "all-at-once";
+    signingIntervalMinutes = 60;
+    freshnessWindow = 180;
+  };
+  rolloutPolicies.all-at-once = {
+    strategy = "all-at-once";
+    waves = [{selector.all = true; soakMinutes = 0;}];
+  };
+  edges = [
+    {after = "a"; before = "b"; reason = "a before b";}
+    {after = "b"; before = "a"; reason = "cycle!";}
+  ];
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/mkFleet.nix tests/lib/mkFleet/negative/edge-cycle.nix
+git commit -m "feat(lib/mkFleet): detect cycles in edges (DAG invariant)"
+```
+
+---
+
+## Task 7: Invariant — disruption budgets satisfiable (warn)
+
+**Files:**
+- Modify: `lib/mkFleet.nix`
+- Create: `tests/lib/mkFleet/fixtures/tight-budget-warns.nix` + `.resolved.json`
+
+- [ ] **Step 1: Extend `resolveFleet` with the budget warning**
+
+In the `resolveFleet` let-binding, add:
+
+```nix
+      budgetWarnings =
+        lib.concatMap (
+          b: let
+            hosts = resolveSelector b.selector cfg.hosts;
+            effectiveMax =
+              if b.maxInFlight != null
+              then b.maxInFlight
+              else if b.maxInFlightPct != null
+              then lib.max 1 ((builtins.length hosts * b.maxInFlightPct) / 100)
+              else builtins.length hosts;
+          in
+            lib.optional (builtins.length hosts >= 10 && effectiveMax == 1)
+            "disruption budget with maxInFlight=1 on ${toString (builtins.length hosts)} hosts will take long to complete"
+        )
+        cfg.disruptionBudgets;
+```
+
+Chain these warnings through the same `lib.warn`/`seq` pattern used for empty-selector warnings.
+
+- [ ] **Step 2: Write the positive fixture (10 hosts, maxInFlight=1)**
+
+```nix
+# tests/lib/mkFleet/fixtures/tight-budget-warns.nix
+{lib, mkFleet}: let
+  mkStubHost = tag: {
+    system = "x86_64-linux";
+    configuration = (import ./_stub-configuration.nix {inherit lib;});
+    tags = [tag];
+    channel = "stable";
+  };
+in
+  mkFleet {
+    hosts = lib.genAttrs (map (n: "host-${toString n}") (lib.range 1 10)) (_: mkStubHost "etcd");
+    channels.stable = {
+      rolloutPolicy = "all-at-once";
+      signingIntervalMinutes = 60;
+      freshnessWindow = 180;
+    };
+    rolloutPolicies.all-at-once = {
+      strategy = "all-at-once";
+      waves = [{selector.all = true; soakMinutes = 0;}];
+    };
+    disruptionBudgets = [{selector.tags = ["etcd"]; maxInFlight = 1;}];
+  }
+```
+
+- [ ] **Step 3: Generate the expected .resolved.json**
+
+User runs the same pattern as Task 4 Step 4.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/mkFleet.nix tests/lib/mkFleet/fixtures/tight-budget-warns.*
+git commit -m "feat(lib/mkFleet): warn when disruption budget is impractically tight"
+```
+
+---
+
+## Task 8: Channel freshness + signing-interval options + cross-field invariant
+
+**Files:**
+- Modify: `lib/mkFleet.nix`
+- Create: `tests/lib/mkFleet/negative/freshness-below-2x.nix`
+
+New invariant from KICKOFF.md §Stream B Milestone 1: `channel.freshnessWindow ≥ 2 × channel.signingIntervalMinutes`.
+
+- [ ] **Step 1: Add the two new options to `channelType`**
+
+In `channelType`, replace with:
+
+```nix
+  channelType = types.submodule {
+    options = {
+      description = mkOption {type = types.str; default = "";};
+      rolloutPolicy = mkOption {type = types.str;};
+      reconcileIntervalMinutes = mkOption {type = types.int; default = 30;};
+      signingIntervalMinutes = mkOption {
+        type = types.int;
+        default = 60;
+        description = ''
+          How often CI re-signs `fleet.resolved` for this channel.
+          Sets the replay-defense floor: a consumer accepts an artifact for
+          at least this long before refresh is expected.
+        '';
+      };
+      freshnessWindow = mkOption {
+        type = types.int;
+        description = ''
+          Minutes a signed `fleet.resolved` artifact is accepted by agents
+          after `meta.signedAt`. MUST be ≥ 2 × signingIntervalMinutes so a
+          single missed signing run does not strand agents.
+        '';
+      };
+      compliance = mkOption {
+        type = types.submodule {
+          options = {
+            strict = mkOption {type = types.bool; default = true;};
+            frameworks = mkOption {type = types.listOf types.str; default = [];};
+          };
+        };
+        default = {};
+      };
+    };
+  };
+```
+
+Note: `freshnessWindow` has NO default — channels must declare it explicitly. This forces operators to think about replay defence per-channel.
+
+- [ ] **Step 2: Add the invariant check**
+
+```nix
+    freshnessErrors =
+      lib.concatMap (
+        channelName: let
+          c = cfg.channels.${channelName};
+        in
+          lib.optional (c.freshnessWindow < 2 * c.signingIntervalMinutes)
+          "channel '${channelName}': freshnessWindow (${toString c.freshnessWindow}) must be ≥ 2 × signingIntervalMinutes (${toString c.signingIntervalMinutes})"
+      )
+      (lib.attrNames cfg.channels);
+```
+
+Add `freshnessErrors` to `errs`.
+
+- [ ] **Step 3: Propagate the fields into `.resolved`**
+
+In `resolveFleet`:
+
+```nix
+      channels =
+        lib.mapAttrs (_: c: {
+          inherit (c) rolloutPolicy reconcileIntervalMinutes signingIntervalMinutes freshnessWindow compliance;
+        })
+        cfg.channels;
+```
+
+- [ ] **Step 4: Write the negative fixture**
+
+```nix
+# tests/lib/mkFleet/negative/freshness-below-2x.nix
+{lib, mkFleet}:
+mkFleet {
+  hosts.m = {
+    system = "x86_64-linux";
+    configuration = (import ../fixtures/_stub-configuration.nix {inherit lib;});
+    tags = [];
+    channel = "stable";
+  };
+  channels.stable = {
+    rolloutPolicy = "all-at-once";
+    signingIntervalMinutes = 60;
+    freshnessWindow = 90; # < 2 × 60, must fail
+  };
+  rolloutPolicies.all-at-once = {
+    strategy = "all-at-once";
+    waves = [{selector.all = true; soakMinutes = 0;}];
+  };
+}
+```
+
+- [ ] **Step 5: Fix every other fixture**
+
+Because `freshnessWindow` is now required, update every fixture from Tasks 3–7 to declare it (value `180` is the minimum safe for the default `signingIntervalMinutes = 60`). Only the new negative test omits it incorrectly.
+
+This is grep-and-fix:
+
+```bash
+grep -L "freshnessWindow" tests/lib/mkFleet/fixtures/*.nix tests/lib/mkFleet/negative/*.nix
+```
+
+Add the two fields where missing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/mkFleet.nix tests/lib/mkFleet/
+git commit -m "feat(lib/mkFleet): require freshnessWindow ≥ 2×signingIntervalMinutes"
+```
+
+---
+
+## Task 9: Host SSH pubkey field (CONTRACTS §II #4)
+
+**Files:**
+- Modify: `lib/mkFleet.nix`
+
+- [ ] **Step 1: Extend `hostType`**
+
+```nix
+  hostType = types.submodule {
+    options = {
+      system = mkOption {type = types.str;};
+      configuration = mkOption {
+        type = types.unspecified;
+        description = "A nixosConfiguration.";
+      };
+      tags = mkOption {type = types.listOf types.str; default = [];};
+      channel = mkOption {type = types.str;};
+      pubkey = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Host SSH ed25519 public key (OpenSSH format). Used by the control
+          plane to verify probe-output signatures and bind the host's mTLS
+          client cert at enrollment. `null` means the host has not been
+          enrolled yet; it appears in the fleet schema but signed artifacts
+          from it cannot be verified.
+        '';
+      };
+    };
+  };
+```
+
+- [ ] **Step 2: Propagate into `.resolved`**
+
+In `resolveFleet`, update the hosts map:
+
+```nix
+      hosts =
+        lib.mapAttrs (_: h: {
+          inherit (h) system tags channel pubkey;
+          closureHash = null;
+        })
+        cfg.hosts;
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/mkFleet.nix
+git commit -m "feat(lib/mkFleet): add hosts.<n>.pubkey for SSH host key declarations"
+```
+
+---
+
+## Task 10: `meta` scaffold (schemaVersion, signedAt, ciCommit)
+
+**Files:**
+- Modify: `lib/mkFleet.nix`
+
+CONTRACTS §I.1 requires `meta.signedAt`, `meta.ciCommit`, `meta.schemaVersion`. CI fills the first two from environment variables at signing time. The evaluator produces a `meta` block with `schemaVersion` pinned and the other two as `null`, plus a helper function that CI calls to overwrite them.
+
+- [ ] **Step 1: Add `meta` to `.resolved`**
+
+In `resolveFleet`, at the top level of the emitted record:
+
+```nix
+      meta = {
+        schemaVersion = 1;
+        signedAt = null; # CI fills via `nixfleet.lib.withSignature`
+        ciCommit = null; # CI fills
+      };
+```
+
+- [ ] **Step 2: Expose `withSignature` helper on the lib**
+
+At the end of `lib/mkFleet.nix`:
+
+```nix
+  withSignature = {
+    signedAt,
+    ciCommit,
+  }: resolved:
+    resolved
+    // {
+      meta = resolved.meta // {inherit signedAt ciCommit;};
+    };
+```
+
+Export it alongside `mkFleet`:
+
+```nix
+in {
+  inherit mkFleet withSignature;
+}
+```
+
+And update `lib/default.nix`:
+
+```nix
+{lib}: let
+  impl = import ./mkFleet.nix {inherit lib;};
+in {
+  inherit (impl) mkFleet withSignature;
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/mkFleet.nix lib/default.nix
+git commit -m "feat(lib/mkFleet): add meta scaffold (schemaVersion, signedAt, ciCommit)"
+```
+
+---
+
+## Task 11: `modules/trust.nix` — nixfleet.trust.* option tree
+
+**Files:**
+- Create: `modules/trust.nix`
+- Create: `modules/tests/trust-options.nix`
+- Modify: `modules/core/_nixos.nix` (or wherever core options are assembled)
+
+- [ ] **Step 1: Write the module**
+
+```nix
+# modules/trust.nix
+#
+# nixfleet.trust.* — the four trust roots from docs/CONTRACTS.md §II.
+# Public keys are declared here; private keys live elsewhere (HSM, host
+# SSH key, offline Yubikey) and never enter this module.
+#
+# Each root supports a `.previous` slot for the 30-day rotation grace
+# window and a shared `rejectBefore` timestamp for compromise response.
+{
+  config,
+  lib,
+  ...
+}: let
+  keySlotType = lib.types.submodule {
+    options = {
+      current = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "Current public key (OpenSSH-armored or framework-specific format).";
+      };
+      previous = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          Previous public key accepted during rotation grace. Remove after
+          the rotation window closes (see docs/CONTRACTS.md §II for
+          per-key grace windows).
+        '';
+      };
+      rejectBefore = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          RFC 3339 timestamp. Signed artifacts older than this are refused
+          regardless of key. Used in compromise response when rolling out
+          a new key is not sufficient (pre-compromise artifacts still
+          carry the old key's trust).
+        '';
+      };
+    };
+  };
+in {
+  options.nixfleet.trust = {
+    ciReleaseKey = lib.mkOption {
+      type = keySlotType;
+      default = {};
+      description = ''
+        CI release key (ed25519). Private half in Stream A's HSM/TPM;
+        public half declared here. Verified by the control plane on every
+        `fleet.resolved` fetch. See docs/CONTRACTS.md §II #1.
+      '';
+    };
+
+    atticCacheKey = lib.mkOption {
+      type = keySlotType;
+      default = {};
+      description = ''
+        Attic binary-cache key. Agents verify before every closure
+        activation. See docs/CONTRACTS.md §II #2.
+      '';
+    };
+
+    orgRootKey = lib.mkOption {
+      type = keySlotType;
+      default = {};
+      description = ''
+        Organization root key. Verifies enrollment tokens at the control
+        plane. Rotation is a catastrophic event — see docs/CONTRACTS.md
+        §II #3.
+      '';
+    };
+  };
+
+  # Assertions make a typo in a declaration a build-time failure rather
+  # than a silent runtime trust hole.
+  config.assertions = [
+    {
+      assertion =
+        config.nixfleet.trust.ciReleaseKey.previous == null
+        || config.nixfleet.trust.ciReleaseKey.current != null;
+      message = "nixfleet.trust.ciReleaseKey: cannot set .previous without .current";
+    }
+    {
+      assertion =
+        config.nixfleet.trust.atticCacheKey.previous == null
+        || config.nixfleet.trust.atticCacheKey.current != null;
+      message = "nixfleet.trust.atticCacheKey: cannot set .previous without .current";
+    }
+    {
+      assertion =
+        config.nixfleet.trust.orgRootKey.previous == null
+        || config.nixfleet.trust.orgRootKey.current != null;
+      message = "nixfleet.trust.orgRootKey: cannot set .previous without .current";
+    }
+  ];
+}
+```
+
+- [ ] **Step 2: Wire into core module export**
+
+Locate the core NixOS module assembly (likely `modules/core/_nixos.nix`). Read it first:
+
+```bash
+head -40 modules/core/_nixos.nix
+```
+
+Add `../trust.nix` to its `imports` list. If this file imports are keyed by attribute, append to the list. If the file doesn't exist, check `modules/core/default.nix` or `modules/flake-module.nix:28-30` (`nixosModules.nixfleet-core = ./core/_nixos.nix`).
+
+- [ ] **Step 3: Write an eval test**
+
+```nix
+# modules/tests/trust-options.nix
+#
+# Eval test for modules/trust.nix. Verifies the option tree shape and the
+# `.previous` without `.current` assertion fires.
+{
+  lib,
+  pkgs,
+  ...
+}: let
+  evalModule = module:
+    (lib.evalModules {
+      modules = [
+        ../trust.nix
+        module
+      ];
+      specialArgs = {inherit pkgs;};
+    }).config;
+
+  happy = evalModule {
+    nixfleet.trust = {
+      ciReleaseKey.current = "ssh-ed25519 AAAA...ci";
+      atticCacheKey.current = "attic:cache.example.com:AAAA...";
+    };
+  };
+
+  broken = builtins.tryEval (
+    (lib.evalModules {
+      modules = [
+        ../trust.nix
+        {
+          nixfleet.trust.ciReleaseKey.previous = "ssh-ed25519 AAAA...old";
+          # current intentionally null
+        }
+        {config.assertions = [];} # force assertions evaluation via dummy
+      ];
+      specialArgs = {inherit pkgs;};
+    }).config.assertions
+  );
+in {
+  happyPath = happy.nixfleet.trust.ciReleaseKey.current;
+  brokenPath = broken;
+}
+```
+
+- [ ] **Step 4: User runs the eval test**
+
+```bash
+nix eval --impure --json --expr 'import ./modules/tests/trust-options.nix { lib = (builtins.getFlake (toString ./.)).inputs.nixpkgs.lib; pkgs = (builtins.getFlake (toString ./.)).inputs.nixpkgs.legacyPackages.x86_64-linux; }'
+```
+
+Expected: JSON with `happyPath = "ssh-ed25519 AAAA...ci"` and `brokenPath.success = true` (the module evals but has a failing assertion — the eval test doesn't fire the assertion because `config.assertions` is only checked at build time, but it does verify the assertions ARE declared).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add modules/trust.nix modules/tests/trust-options.nix modules/core/_nixos.nix
+git commit -m "feat(modules): add nixfleet.trust.* option tree for trust roots"
+```
+
+---
+
+## Task 12: Homelab example end-to-end
+
+**Files:**
+- Create: `examples/fleet-homelab/flake.nix`
+- Create: `examples/fleet-homelab/fleet.nix`
+- Create: `examples/fleet-homelab/hosts/m70q.nix`
+- Create: `examples/fleet-homelab/hosts/workstation.nix`
+- Create: `examples/fleet-homelab/hosts/rpi-sensor.nix`
+
+- [ ] **Step 1: Copy the spike example as a starting point**
+
+```bash
+cp -r spike/examples/homelab examples/fleet-homelab
+```
+
+- [ ] **Step 2: Update `examples/fleet-homelab/flake.nix` to point at the promoted lib**
+
+```nix
+{
+  description = "nixfleet homelab example — exercises lib/mkFleet.nix";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixfleet.url = "path:../..";
+    nixfleet.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    nixfleet,
+    ...
+  }: {
+    nixosConfigurations = {
+      m70q-attic = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [./hosts/m70q.nix];
+      };
+      workstation = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [./hosts/workstation.nix];
+      };
+      rpi-sensor-01 = nixpkgs.lib.nixosSystem {
+        system = "aarch64-linux";
+        modules = [./hosts/rpi-sensor.nix];
+      };
+    };
+
+    fleet = import ./fleet.nix {
+      inherit self nixfleet;
+    };
+  };
+}
+```
+
+- [ ] **Step 3: Rewrite `examples/fleet-homelab/fleet.nix` with new fields**
+
+```nix
+{
+  self,
+  nixfleet,
+  ...
+}:
+nixfleet.lib.mkFleet {
+  hosts = {
+    m70q-attic = {
+      system = "x86_64-linux";
+      configuration = self.nixosConfigurations.m70q-attic;
+      tags = ["homelab" "always-on" "eu-fr" "server" "coordinator"];
+      channel = "stable";
+      pubkey = null; # filled in post-enrollment
+    };
+    workstation = {
+      system = "x86_64-linux";
+      configuration = self.nixosConfigurations.workstation;
+      tags = ["homelab" "eu-fr" "workstation" "builder"];
+      channel = "stable";
+      pubkey = null;
+    };
+    rpi-sensor-01 = {
+      system = "aarch64-linux";
+      configuration = self.nixosConfigurations.rpi-sensor-01;
+      tags = ["edge" "eu-fr" "sensor" "low-power"];
+      channel = "edge-slow";
+      pubkey = null;
+    };
+  };
+
+  channels = {
+    stable = {
+      description = "Workstation canary → M70q promote.";
+      rolloutPolicy = "homelab-canary";
+      reconcileIntervalMinutes = 30;
+      signingIntervalMinutes = 60;
+      freshnessWindow = 180;
+      compliance = {
+        strict = true;
+        frameworks = ["anssi-bp028"];
+      };
+    };
+    edge-slow = {
+      description = "Low-power sensors; weekly reconcile.";
+      rolloutPolicy = "all-at-once";
+      reconcileIntervalMinutes = 10080;
+      signingIntervalMinutes = 60;
+      freshnessWindow = 20160; # 14 days
+    };
+  };
+
+  rolloutPolicies = {
+    homelab-canary = {
+      strategy = "canary";
+      waves = [
+        {selector.tags = ["workstation"]; soakMinutes = 30;}
+        {selector.tags = ["always-on"]; soakMinutes = 60;}
+      ];
+      healthGate = {systemdFailedUnits.max = 0;};
+      onHealthFailure = "rollback-and-halt";
+    };
+    all-at-once = {
+      strategy = "all-at-once";
+      waves = [{selector.all = true; soakMinutes = 0;}];
+      healthGate = {systemdFailedUnits.max = 0;};
+    };
+  };
+
+  edges = [];
+
+  disruptionBudgets = [
+    {selector.tags = ["always-on"]; maxInFlight = 1;}
+    {selector.tags = ["coordinator"]; maxInFlight = 1;}
+  ];
+}
+```
+
+- [ ] **Step 4: User evaluates end-to-end**
+
+```bash
+nix eval --json ./examples/fleet-homelab#fleet.resolved | jq . | tee tests/lib/mkFleet/fixtures/homelab.resolved.json
+```
+
+Expected: a JSON object with `schemaVersion: 1`, `meta: { schemaVersion: 1, signedAt: null, ciCommit: null }`, three hosts, two channels with freshnessWindow and signingIntervalMinutes fields, waves, and disruption budgets. Commit the generated fixture.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add examples/fleet-homelab/ tests/lib/mkFleet/fixtures/homelab.resolved.json
+git commit -m "feat(examples): add homelab example exercising lib/mkFleet end-to-end"
+```
+
+---
+
+## Task 13: Golden-file acceptance test
+
+**Files:**
+- Create: `tests/lib/mkFleet/fixtures/homelab.nix`
+
+- [ ] **Step 1: Write a fixture that imports the homelab example**
+
+```nix
+# tests/lib/mkFleet/fixtures/homelab.nix
+{lib, mkFleet}: import ../../../examples/fleet-homelab/fleet.nix {
+  inherit lib;
+  nixfleet.lib.mkFleet = mkFleet;
+  self.nixosConfigurations = let
+    stub = import ./_stub-configuration.nix {inherit lib;};
+  in {
+    m70q-attic = stub;
+    workstation = stub;
+    rpi-sensor-01 = stub;
+  };
+}
+```
+
+- [ ] **Step 2: Regenerate the golden from this path to keep them in sync**
+
+User runs:
+
+```bash
+nix eval --impure --json --expr '(import ./tests/lib/mkFleet/fixtures/homelab.nix { lib = (builtins.getFlake (toString ./.)).inputs.nixpkgs.lib; mkFleet = (import ./lib/mkFleet.nix { lib = (builtins.getFlake (toString ./.)).inputs.nixpkgs.lib; }).mkFleet; }).resolved' | jq . > tests/lib/mkFleet/fixtures/homelab.resolved.json
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/lib/mkFleet/fixtures/homelab.nix tests/lib/mkFleet/fixtures/homelab.resolved.json
+git commit -m "test(lib/mkFleet): golden-file acceptance fixture for homelab example"
+```
+
+---
+
+## Task 14: JCS canonicalization shape hook
+
+**Files:**
+- Modify: `lib/mkFleet.nix`
+- Modify: `docs/CONTRACTS.md` (only a line comment — the choice is Stream C's)
+
+CONTRACTS §III: "JCS (RFC 8785) with a single Rust implementation". Stream B does NOT pick the library — Stream C does. But the Nix output must be JCS-ready: that means no floating-point values we care about equality on, no ambiguous Unicode in keys, no hidden attribute order.
+
+- [ ] **Step 1: Verify the resolved output is JCS-friendly**
+
+All our values are ints, strings, lists, and plain attribute sets. Attribute sets are deterministically ordered by Nix. No floats. No Unicode normalization issues in the homelab fixture. This is property-verified by the golden-file test in Task 13.
+
+Add a comment at the top of `lib/mkFleet.nix`:
+
+```nix
+# lib/mkFleet.nix
+#
+# Produces `fleet.resolved` per RFC-0001 §4.1 + docs/CONTRACTS.md §I #1.
+# Output is canonicalized to JCS (RFC 8785) by `bin/nixfleet-canonicalize`
+# (owned by Stream C) before signing — DO NOT introduce floats, opaque
+# derivations, or attrsets whose iteration order is significant here.
+```
+
+- [ ] **Step 2: Cross-link from CONTRACTS.md**
+
+Edit `docs/CONTRACTS.md` §III first paragraph to add:
+
+```markdown
+Producer-side (Stream B's `lib/mkFleet.nix`) MUST emit values that round-trip through JCS losslessly: ints only (no floats), deterministic attr order, no JSON-incompatible types. Consumer-side (Stream C's `bin/nixfleet-canonicalize`) pins the library.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/mkFleet.nix docs/CONTRACTS.md
+git commit -m "docs(contracts): pin JCS producer-side discipline in lib/mkFleet"
+```
+
+This is a CONTRACTS.md edit — mark the PR with `contract-change` when opening. Stream C and Stream A must sign off per KICKOFF.md §1 merge discipline.
+
+---
+
+## Task 15: CHANGELOG + README
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `README.md` (if it has a "What's new" section)
+
+- [ ] **Step 1: Add CHANGELOG entry under `## [Unreleased]`**
+
+Open `CHANGELOG.md` and add under `### Added`:
+
+```markdown
+- `lib.mkFleet` — evaluates a declarative fleet description and emits a
+  typed `.resolved` artifact per RFC-0001. Every invariant from §4.2 is
+  enforced at eval time: host/channel/policy references, edge DAG,
+  compliance framework allow-list, and the cross-field
+  `freshnessWindow ≥ 2 × signingIntervalMinutes` relation.
+- `nixfleet.trust.*` option tree — declares CI release key, attic cache
+  key, and org root key (with rotation grace slots and a compromise
+  `rejectBefore` switch).
+- `examples/fleet-homelab/` — a working end-to-end example producing a
+  signed-shape `fleet.resolved`.
+```
+
+- [ ] **Step 2: If `README.md` has a quick-start, extend it with one line showing `nix eval .#fleet.resolved`**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md README.md
+git commit -m "docs: note lib.mkFleet and nixfleet.trust.* in changelog"
+```
+
+---
+
+## Task 16: Wire into CI + `nix flake check`
+
+**Files:**
+- Modify: `flake.nix` or `modules/tests/*.nix`
+
+- [ ] **Step 1: Add eval test entry point**
+
+Find where `flake.checks` is assembled (likely `modules/tests/eval.nix` or perSystem in the main flake). Add a derivation that runs the mkFleet harness:
+
+```nix
+# In the checks assembly:
+mkFleet-eval-tests = pkgs.runCommand "mkFleet-eval-tests" {} ''
+  ${pkgs.nix}/bin/nix-instantiate --eval --json --strict \
+    --argstr unused 'unused' \
+    -E '(import ${./tests/lib/mkFleet/default.nix} { lib = (import <nixpkgs> {}).lib; })' > $out
+'';
+```
+
+(Adjust pattern to match the project's actual checks scaffold.)
+
+- [ ] **Step 2: User verifies `nix flake check` picks up the new test**
+
+```bash
+nix flake check --no-build 2>&1 | grep -i mkFleet
+```
+
+Expected: reference to `mkFleet-eval-tests` in the checks list.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add flake.nix modules/tests/
+git commit -m "ci: wire lib/mkFleet eval tests into nix flake check"
+```
+
+---
+
+## Task 17: Tracking-issue sync + PR
+
+**Files:**
+- `abstracts33d/nixfleet#10` (comment on tracking issue)
+- PR on `abstracts33d/nixfleet`
+
+- [ ] **Step 1: User-facing summary**
+
+Before opening a PR, present to the user:
+
+```
+Branch: feat/mkfleet-promotion
+Closes: abstracts33d/nixfleet#1 (and the Nix portion of #12)
+Commits: N commits, each atomic per task above
+Acceptance: `nix eval --json ./examples/fleet-homelab#fleet.resolved`
+produces a schemaVersion:1 artifact matching the golden file.
+
+Review OK, can I ship?
+```
+
+WAIT for explicit confirmation.
+
+- [ ] **Step 2: On confirmation — push and open the PR**
+
+```bash
+git push -u origin feat/mkfleet-promotion
+gh pr create --repo abstracts33d/nixfleet \
+  --title "feat: promote mkFleet + add nixfleet.trust.* option tree (#1)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Promote `spike/lib/mkFleet.nix` → `lib/mkFleet.nix` with every RFC-0001 §4.2 invariant enforced.
+- New cross-field invariant: `channel.freshnessWindow ≥ 2 × signingIntervalMinutes` (closes the Nix portion of #12 freshness coverage).
+- Add `modules/trust.nix` with `nixfleet.trust.ciReleaseKey`, `.atticCacheKey`, `.orgRootKey` (each with `.previous` grace slot and `rejectBefore` compromise switch).
+- End-to-end example in `examples/fleet-homelab/` + golden-file acceptance test.
+- CONTRACTS.md edit: producer-side JCS discipline line (requires Stream A and Stream C signoff per `contract-change` rule).
+
+## Acceptance
+- `nix eval --json ./examples/fleet-homelab#fleet.resolved` produces a `schemaVersion: 1` artifact byte-identical to `tests/lib/mkFleet/fixtures/homelab.resolved.json`.
+- `nix flake check` runs the positive and negative mkFleet fixtures.
+
+## Test plan
+- [ ] Eval positive fixtures pass
+- [ ] Each negative fixture throws as expected
+- [ ] `nixfleet.trust.*` assertion fires when `.previous` set without `.current`
+- [ ] Homelab example evaluates cleanly against the golden file
+
+Closes #1
+Partial: #12 (Nix portion — signing tooling lands in Stream C)
+EOF
+)"
+```
+
+- [ ] **Step 3: Post cross-stream status on tracking issue**
+
+```bash
+gh issue comment 10 --repo abstracts33d/nixfleet --body "$(cat <<'EOF'
+Stream B — Milestone 1 (nixfleet side): mkFleet promoted, nixfleet.trust.* landed. PR #NN. Note: CONTRACTS.md §III now documents producer-side JCS discipline — Stream A and Stream C signoff requested on the PR.
+EOF
+)"
+```
+
+---
+
+## Self-Review Checklist
+
+- [x] Every RFC-0001 §4.2 invariant implemented: host config validity (Task 3), channel lookup (spike baseline), policy lookup (spike baseline), empty selector warn (Task 4), compliance framework allow-list (Task 5), DAG check (Task 6), disruption budget warn (Task 7).
+- [x] New invariant `freshnessWindow ≥ 2 × signingIntervalMinutes` in Task 8.
+- [x] `hosts.<n>.pubkey` in Task 9.
+- [x] `meta` scaffold in Task 10.
+- [x] `nixfleet.trust.*` option tree in Task 11.
+- [x] End-to-end example in Task 12.
+- [x] Golden-file test in Task 13.
+- [x] JCS producer-side discipline pinned in Task 14.
+- [x] Docs in Task 15.
+- [x] CI wiring in Task 16.
+- [x] No placeholders; every code block is complete.
+- [x] No referenced symbol is undefined: `checkInvariants`, `resolveSelector`, `resolveFleet`, `hasCycle`, `withSignature`, `keySlotType`, `channelType`, `hostType` are all defined where referenced.
+- [x] Contract change (Task 14) flagged for cross-stream signoff per KICKOFF.md discipline.

--- a/examples/fleet-homelab/flake.lock
+++ b/examples/fleet-homelab/flake.lock
@@ -1,0 +1,713 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1776533550,
+        "narHash": "sha256-8mTHsQ8cB0jGlXE4WWKqpQFQPM/VotDnr2uzfrOGNKI=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "e24d86e91348e3d44014974fa24c9a22cfd663b5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_2": {
+      "locked": {
+        "lastModified": 1765145449,
+        "narHash": "sha256-aBVHGWWRzSpfL++LubA0CwOOQ64WNLegrYHwsVuVN7A=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "69f538cdce5955fcd47abfed4395dc6d5194c1c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixfleet",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773000227,
+        "narHash": "sha256-zm3ftUQw0MPumYi91HovoGhgyZBlM4o3Zy0LhPNwzXE=",
+        "owner": "LnL7",
+        "repo": "nix-darwin",
+        "rev": "da529ac9e46f25ed5616fd634079a5f3c579135f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "LnL7",
+        "ref": "master",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "disko": {
+      "inputs": {
+        "nixpkgs": [
+          "nixfleet",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773889306,
+        "narHash": "sha256-PAqwnsBSI9SVC2QugvQ3xeYCB0otOwCacB1ueQj2tgw=",
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "5ad85c82cc52264f4beddc934ba57f3789f28347",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "disko",
+        "type": "github"
+      }
+    },
+    "disko_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixfleet",
+          "nixfleet-scopes",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773889306,
+        "narHash": "sha256-PAqwnsBSI9SVC2QugvQ3xeYCB0otOwCacB1ueQj2tgw=",
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "5ad85c82cc52264f4beddc934ba57f3789f28347",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "disko",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1761588595,
+        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "nixfleet",
+          "lanzaboote",
+          "pre-commit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixfleet",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774559017,
+        "narHash": "sha256-MjKxN6G+37w70x993Nm4T/99g+pmXFGecNlbxJdC4rk=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "0e0e7a072ac50028c433760b38222700583b3676",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixfleet",
+          "impermanence",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768598210,
+        "narHash": "sha256-kkgA32s/f4jaa4UG+2f8C225Qvclxnqs76mf8zvTVPg=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "c47b2cc64a629f8e075de52e4742de688f930dc6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager_3": {
+      "inputs": {
+        "nixpkgs": [
+          "nixfleet",
+          "nixfleet-scopes",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776184304,
+        "narHash": "sha256-No6QGBmIv5ChiwKCcbkxjdEQ/RO2ZS1gD7SFy6EZ7rc=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "3c7524c68348ef79ce48308e0978611a050089b2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager_4": {
+      "inputs": {
+        "nixpkgs": [
+          "nixfleet",
+          "nixfleet-scopes",
+          "impermanence",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768598210,
+        "narHash": "sha256-kkgA32s/f4jaa4UG+2f8C225Qvclxnqs76mf8zvTVPg=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "c47b2cc64a629f8e075de52e4742de688f930dc6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "impermanence": {
+      "inputs": {
+        "home-manager": "home-manager_2",
+        "nixpkgs": [
+          "nixfleet",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769548169,
+        "narHash": "sha256-03+JxvzmfwRu+5JafM0DLbxgHttOQZkUtDWBmeUkN8Y=",
+        "owner": "nix-community",
+        "repo": "impermanence",
+        "rev": "7b1d382faf603b6d264f58627330f9faa5cba149",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "impermanence",
+        "type": "github"
+      }
+    },
+    "impermanence_2": {
+      "inputs": {
+        "home-manager": "home-manager_4",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1769548169,
+        "narHash": "sha256-03+JxvzmfwRu+5JafM0DLbxgHttOQZkUtDWBmeUkN8Y=",
+        "owner": "nix-community",
+        "repo": "impermanence",
+        "rev": "7b1d382faf603b6d264f58627330f9faa5cba149",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "impermanence",
+        "type": "github"
+      }
+    },
+    "import-tree": {
+      "locked": {
+        "lastModified": 1773693634,
+        "narHash": "sha256-BtZ2dtkBdSUnFPPFc+n0kcMbgaTxzFNPv2iaO326Ffg=",
+        "owner": "vic",
+        "repo": "import-tree",
+        "rev": "c41e7d58045f9057880b0d85e1152d6a4430dbf1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vic",
+        "repo": "import-tree",
+        "type": "github"
+      }
+    },
+    "lanzaboote": {
+      "inputs": {
+        "crane": "crane_2",
+        "nixpkgs": [
+          "nixfleet",
+          "nixpkgs"
+        ],
+        "pre-commit": "pre-commit",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1765382359,
+        "narHash": "sha256-RJmgVDzjRI18BWVogG6wpsl1UCuV6ui8qr4DJ1LfWZ8=",
+        "owner": "nix-community",
+        "repo": "lanzaboote",
+        "rev": "e8c096ade12ec9130ff931b0f0e25d2f1bc63607",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "v1.0.0",
+        "repo": "lanzaboote",
+        "type": "github"
+      }
+    },
+    "microvm": {
+      "inputs": {
+        "nixpkgs": [
+          "nixfleet",
+          "nixpkgs"
+        ],
+        "spectrum": "spectrum"
+      },
+      "locked": {
+        "lastModified": 1775329298,
+        "narHash": "sha256-xmntQolopr1WwBO5rAC+SKyON+ritVQLUHZdvpjUM90=",
+        "owner": "astro",
+        "repo": "microvm.nix",
+        "rev": "4a9ff5adcefd23e68de76f33ebc7b3909e06c09b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "astro",
+        "repo": "microvm.nix",
+        "type": "github"
+      }
+    },
+    "nix-vm-test": {
+      "inputs": {
+        "nixpkgs": [
+          "nixfleet",
+          "nixos-anywhere",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769079217,
+        "narHash": "sha256-R6qzhu+YJolxE2vUsPQWWwUKMbAG5nXX3pBtg8BNX38=",
+        "owner": "Enzime",
+        "repo": "nix-vm-test",
+        "rev": "58c15f78947b431d6c206e0966500c7e9139bd2f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Enzime",
+        "ref": "pr-105-latest",
+        "repo": "nix-vm-test",
+        "type": "github"
+      }
+    },
+    "nixfleet": {
+      "inputs": {
+        "crane": "crane",
+        "darwin": "darwin",
+        "disko": "disko",
+        "flake-parts": "flake-parts",
+        "home-manager": "home-manager",
+        "impermanence": "impermanence",
+        "import-tree": "import-tree",
+        "lanzaboote": "lanzaboote",
+        "microvm": "microvm",
+        "nixfleet-scopes": "nixfleet-scopes",
+        "nixos-anywhere": "nixos-anywhere",
+        "nixos-hardware": "nixos-hardware",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
+        "path": "../..",
+        "type": "path"
+      },
+      "original": {
+        "path": "../..",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "nixfleet-scopes": {
+      "inputs": {
+        "disko": "disko_2",
+        "flake-parts": "flake-parts_2",
+        "home-manager": "home-manager_3",
+        "impermanence": "impermanence_2",
+        "nixpkgs": [
+          "nixfleet",
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1776720121,
+        "narHash": "sha256-2p+q/Ed1DepM7E+MyUB34aspXgoTROenWSYE0vhFkMk=",
+        "owner": "arcanesys",
+        "repo": "nixfleet-scopes",
+        "rev": "b441a275959570ea2c7ac12b25e6f3f473badff1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "arcanesys",
+        "repo": "nixfleet-scopes",
+        "type": "github"
+      }
+    },
+    "nixos-anywhere": {
+      "inputs": {
+        "disko": [
+          "nixfleet",
+          "disko"
+        ],
+        "flake-parts": [
+          "nixfleet",
+          "flake-parts"
+        ],
+        "nix-vm-test": "nix-vm-test",
+        "nixos-images": "nixos-images",
+        "nixos-stable": "nixos-stable",
+        "nixpkgs": [
+          "nixfleet",
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "nixfleet",
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769956140,
+        "narHash": "sha256-D+RQ+DaIC/GVwv5lUs7e8jSmh8aPc77Kg/gRjaS25Zk=",
+        "owner": "nix-community",
+        "repo": "nixos-anywhere",
+        "rev": "92f82c5196a5f8588be4967e535c4cfd35e85902",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixos-anywhere",
+        "type": "github"
+      }
+    },
+    "nixos-hardware": {
+      "locked": {
+        "lastModified": 1774465523,
+        "narHash": "sha256-4v7HPm63Q90nNn4fgkgKsjW1AH2Klw7XzPtHJr562nM=",
+        "owner": "NixOS",
+        "repo": "nixos-hardware",
+        "rev": "de895be946ad1d8aafa0bb6dfc7e7e0e9e466a29",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixos-hardware",
+        "type": "github"
+      }
+    },
+    "nixos-images": {
+      "inputs": {
+        "nixos-stable": [
+          "nixfleet",
+          "nixos-anywhere",
+          "nixos-stable"
+        ],
+        "nixos-unstable": [
+          "nixfleet",
+          "nixos-anywhere",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1766770015,
+        "narHash": "sha256-kUmVBU+uBUPl/v3biPiWrk680b8N9rRMhtY97wsxiJc=",
+        "owner": "nix-community",
+        "repo": "nixos-images",
+        "rev": "e4dba54ddb6b2ad9c6550e5baaed2fa27938a5d2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixos-images",
+        "type": "github"
+      }
+    },
+    "nixos-stable": {
+      "locked": {
+        "lastModified": 1769598131,
+        "narHash": "sha256-e7VO/kGLgRMbWtpBqdWl0uFg8Y2XWFMdz0uUJvlML8o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fa83fd837f3098e3e678e6cf017b2b36102c7211",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1768564909,
+        "narHash": "sha256-Kell/SpJYVkHWMvnhqJz/8DqQg2b6PguxVWOuadbHCc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e4bae1bd10c9c57b2cf517953ab70060a828ee6f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1772328832,
+        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1776949667,
+        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixfleet",
+          "lanzaboote",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1765016596,
+        "narHash": "sha256-rhSqPNxDVow7OQKi4qS5H8Au0P4S3AYbawBSmJNUtBQ=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "548fc44fca28a5e81c5d6b846e555e6b9c2a5a3c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixfleet": "nixfleet",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixfleet",
+          "lanzaboote",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1765075567,
+        "narHash": "sha256-KFDCdQcHJ0hE3Nt5Gm5enRIhmtEifAjpxgUQ3mzSJpA=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "769156779b41e8787a46ca3d7d76443aaf68be6f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "spectrum": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772189877,
+        "narHash": "sha256-i1p90Rgssb//aNiTDFq46ZG/fk3LmyRLChtp/9lddyA=",
+        "ref": "refs/heads/main",
+        "rev": "fe39e122d898f66e89ffa17d4f4209989ccb5358",
+        "revCount": 1255,
+        "type": "git",
+        "url": "https://spectrum-os.org/git/spectrum"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://spectrum-os.org/git/spectrum"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixfleet",
+          "nixfleet-scopes",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixfleet",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773297127,
+        "narHash": "sha256-6E/yhXP7Oy/NbXtf1ktzmU8SdVqJQ09HC/48ebEGBpk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "71b125cd05fbfd78cab3e070b73544abe24c5016",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/examples/fleet-homelab/flake.nix
+++ b/examples/fleet-homelab/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "nixfleet homelab example — exercises lib/mkFleet.nix";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixfleet.url = "path:../..";
+    nixfleet.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    nixfleet,
+    ...
+  }: {
+    nixosConfigurations = {
+      m70q-attic = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [./hosts/m70q.nix];
+      };
+      workstation = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [./hosts/workstation.nix];
+      };
+      rpi-sensor-01 = nixpkgs.lib.nixosSystem {
+        system = "aarch64-linux";
+        modules = [./hosts/rpi-sensor.nix];
+      };
+    };
+
+    fleet = import ./fleet.nix {
+      inherit self nixfleet;
+    };
+  };
+}

--- a/examples/fleet-homelab/fleet.nix
+++ b/examples/fleet-homelab/fleet.nix
@@ -1,0 +1,92 @@
+{
+  self,
+  nixfleet,
+  ...
+}:
+nixfleet.lib.mkFleet {
+  hosts = {
+    m70q-attic = {
+      system = "x86_64-linux";
+      configuration = self.nixosConfigurations.m70q-attic;
+      tags = ["homelab" "always-on" "eu-fr" "server" "coordinator"];
+      channel = "stable";
+      pubkey = null;
+    };
+    workstation = {
+      system = "x86_64-linux";
+      configuration = self.nixosConfigurations.workstation;
+      tags = ["homelab" "eu-fr" "workstation" "builder"];
+      channel = "stable";
+      pubkey = null;
+    };
+    rpi-sensor-01 = {
+      system = "aarch64-linux";
+      configuration = self.nixosConfigurations.rpi-sensor-01;
+      tags = ["edge" "eu-fr" "sensor" "low-power"];
+      channel = "edge-slow";
+      pubkey = null;
+    };
+  };
+
+  channels = {
+    stable = {
+      description = "Workstation canary → M70q promote.";
+      rolloutPolicy = "homelab-canary";
+      reconcileIntervalMinutes = 30;
+      signingIntervalMinutes = 60;
+      freshnessWindow = 180;
+      compliance = {
+        strict = true;
+        frameworks = ["anssi-bp028"];
+      };
+    };
+    edge-slow = {
+      description = "Low-power sensors; weekly reconcile.";
+      rolloutPolicy = "all-at-once";
+      reconcileIntervalMinutes = 10080;
+      signingIntervalMinutes = 60;
+      freshnessWindow = 20160;
+    };
+  };
+
+  rolloutPolicies = {
+    homelab-canary = {
+      strategy = "canary";
+      waves = [
+        {
+          selector.tags = ["workstation"];
+          soakMinutes = 30;
+        }
+        {
+          selector.tags = ["always-on"];
+          soakMinutes = 60;
+        }
+      ];
+      healthGate = {systemdFailedUnits.max = 0;};
+      onHealthFailure = "rollback-and-halt";
+    };
+    all-at-once = {
+      strategy = "all-at-once";
+      waves = [
+        {
+          selector.all = true;
+          soakMinutes = 0;
+        }
+      ];
+      healthGate = {systemdFailedUnits.max = 0;};
+    };
+  };
+
+  edges = [];
+
+  disruptionBudgets = [
+    {
+      selector.tags = ["always-on"];
+      maxInFlight = 1;
+    }
+    {
+      selector.tags = ["coordinator"];
+      maxInFlight = 1;
+    }
+  ];
+}

--- a/examples/fleet-homelab/hosts/m70q.nix
+++ b/examples/fleet-homelab/hosts/m70q.nix
@@ -1,0 +1,9 @@
+{...}: {
+  networking.hostName = "m70q-attic";
+  system.stateVersion = "25.11";
+  boot.loader.grub.device = "nodev";
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/nixos";
+    fsType = "ext4";
+  };
+}

--- a/examples/fleet-homelab/hosts/rpi-sensor.nix
+++ b/examples/fleet-homelab/hosts/rpi-sensor.nix
@@ -1,0 +1,10 @@
+{...}: {
+  networking.hostName = "rpi-sensor-01";
+  nixpkgs.hostPlatform = "aarch64-linux";
+  system.stateVersion = "25.11";
+  boot.loader.grub.device = "nodev";
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/nixos";
+    fsType = "ext4";
+  };
+}

--- a/examples/fleet-homelab/hosts/workstation.nix
+++ b/examples/fleet-homelab/hosts/workstation.nix
@@ -1,0 +1,9 @@
+{...}: {
+  networking.hostName = "workstation";
+  system.stateVersion = "25.11";
+  boot.loader.grub.device = "nodev";
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/nixos";
+    fsType = "ext4";
+  };
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -3,6 +3,8 @@
 # nixfleet library entry point. Imports are keyed by capability so consumers
 # can depend on narrow slices (e.g. just `mkFleet`) without pulling the full
 # framework module graph.
-{lib}: {
-  mkFleet = (import ./mkFleet.nix {inherit lib;}).mkFleet;
+{lib}: let
+  impl = import ./mkFleet.nix {inherit lib;};
+in {
+  inherit (impl) mkFleet withSignature;
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,0 +1,8 @@
+# lib/default.nix
+#
+# nixfleet library entry point. Imports are keyed by capability so consumers
+# can depend on narrow slices (e.g. just `mkFleet`) without pulling the full
+# framework module graph.
+{lib}: {
+  mkFleet = (import ./mkFleet.nix {inherit lib;}).mkFleet;
+}

--- a/lib/flake-module.nix
+++ b/lib/flake-module.nix
@@ -1,8 +1,0 @@
-# lib/flake-module.nix
-#
-# Exposes `config.flake.lib.mkFleet` via flake-parts so consumers can call
-# `nixfleet.lib.mkFleet { ... }` from their own flakes.
-{lib, ...}: {
-  config.flake.lib.mkFleet =
-    (import ./mkFleet.nix {inherit lib;}).mkFleet;
-}

--- a/lib/flake-module.nix
+++ b/lib/flake-module.nix
@@ -1,0 +1,8 @@
+# lib/flake-module.nix
+#
+# Exposes `config.flake.lib.mkFleet` via flake-parts so consumers can call
+# `nixfleet.lib.mkFleet { ... }` from their own flakes.
+{lib, ...}: {
+  config.flake.lib.mkFleet =
+    (import ./mkFleet.nix {inherit lib;}).mkFleet;
+}

--- a/lib/mkFleet.nix
+++ b/lib/mkFleet.nix
@@ -202,39 +202,61 @@
 
   # --- Resolved projection (RFC-0001 §4.1) ---
   resolveFleet = cfg:
-    assert checkInvariants cfg; {
-      schemaVersion = 1;
-      hosts =
-        lib.mapAttrs (_: h: {
-          inherit (h) system tags channel;
-          closureHash = null; # CI fills this in from h.configuration.config.system.build.toplevel
-        })
-        cfg.hosts;
-      channels =
-        lib.mapAttrs (_: c: {
-          inherit (c) rolloutPolicy reconcileIntervalMinutes compliance;
-        })
-        cfg.channels;
-      rolloutPolicies = cfg.rolloutPolicies;
-      waves =
-        lib.mapAttrs (
-          _: c:
-            map (w: {
-              hosts = resolveSelector w.selector cfg.hosts;
-              soakMinutes = w.soakMinutes;
-            })
-            cfg.rolloutPolicies.${c.rolloutPolicy}.waves
+    assert checkInvariants cfg; let
+      emptySelectorWarnings =
+        lib.concatMap (
+          policyName:
+            lib.concatMap (
+              w: let
+                hosts = resolveSelector w.selector cfg.hosts;
+              in
+                lib.optional (hosts == [])
+                "rollout policy '${policyName}' has a wave with a selector that resolves to zero hosts"
+            )
+            cfg.rolloutPolicies.${policyName}.waves
         )
-        cfg.channels;
-      edges = cfg.edges;
-      disruptionBudgets =
-        map (b: {
-          hosts = resolveSelector b.selector cfg.hosts;
-          maxInFlight = b.maxInFlight;
-          maxInFlightPct = b.maxInFlightPct;
-        })
-        cfg.disruptionBudgets;
-    };
+        (lib.attrNames cfg.rolloutPolicies);
+
+      # Force the warnings side effect before returning the resolved value.
+      # `lib.warn` prints to stderr during eval and returns its second arg.
+      emittedWarnings =
+        lib.foldl' (acc: msg: lib.warn msg acc) null emptySelectorWarnings;
+
+      resolved = {
+        schemaVersion = 1;
+        hosts =
+          lib.mapAttrs (_: h: {
+            inherit (h) system tags channel;
+            closureHash = null; # CI fills this in from h.configuration.config.system.build.toplevel
+          })
+          cfg.hosts;
+        channels =
+          lib.mapAttrs (_: c: {
+            inherit (c) rolloutPolicy reconcileIntervalMinutes compliance;
+          })
+          cfg.channels;
+        rolloutPolicies = cfg.rolloutPolicies;
+        waves =
+          lib.mapAttrs (
+            _: c:
+              map (w: {
+                hosts = resolveSelector w.selector cfg.hosts;
+                soakMinutes = w.soakMinutes;
+              })
+              cfg.rolloutPolicies.${c.rolloutPolicy}.waves
+          )
+          cfg.channels;
+        edges = cfg.edges;
+        disruptionBudgets =
+          map (b: {
+            hosts = resolveSelector b.selector cfg.hosts;
+            maxInFlight = b.maxInFlight;
+            maxInFlightPct = b.maxInFlightPct;
+          })
+          cfg.disruptionBudgets;
+      };
+    in
+      builtins.seq emittedWarnings resolved;
 in {
   mkFleet = input: let
     evaluated = lib.evalModules {

--- a/lib/mkFleet.nix
+++ b/lib/mkFleet.nix
@@ -91,6 +91,23 @@
         type = types.int;
         default = 30;
       };
+      signingIntervalMinutes = mkOption {
+        type = types.int;
+        default = 60;
+        description = ''
+          How often CI re-signs `fleet.resolved` for this channel.
+          Sets the replay-defense floor: a consumer accepts an artifact for
+          at least this long before refresh is expected.
+        '';
+      };
+      freshnessWindow = mkOption {
+        type = types.int;
+        description = ''
+          Minutes a signed `fleet.resolved` artifact is accepted by agents
+          after `meta.signedAt`. MUST be ≥ 2 × signingIntervalMinutes so a
+          single missed signing run does not strand agents.
+        '';
+      };
       compliance = mkOption {
         type = types.submodule {
           options = {
@@ -277,7 +294,17 @@
 
     cycleErrors = lib.optional (hasCycle cfg.edges) "edges form a cycle; the DAG invariant is violated";
 
-    errs = hostChannelErrors ++ channelPolicyErrors ++ edgeErrors ++ configurationErrors ++ complianceErrors ++ cycleErrors;
+    freshnessErrors =
+      lib.concatMap (
+        channelName: let
+          c = cfg.channels.${channelName};
+        in
+          lib.optional (c.freshnessWindow < 2 * c.signingIntervalMinutes)
+          "channel '${channelName}': freshnessWindow (${toString c.freshnessWindow}) must be ≥ 2 × signingIntervalMinutes (${toString c.signingIntervalMinutes})"
+      )
+      (lib.attrNames cfg.channels);
+
+    errs = hostChannelErrors ++ channelPolicyErrors ++ edgeErrors ++ configurationErrors ++ complianceErrors ++ cycleErrors ++ freshnessErrors;
   in
     if errs == []
     then true
@@ -333,7 +360,7 @@
           cfg.hosts;
         channels =
           lib.mapAttrs (_: c: {
-            inherit (c) rolloutPolicy reconcileIntervalMinutes compliance;
+            inherit (c) rolloutPolicy reconcileIntervalMinutes signingIntervalMinutes freshnessWindow compliance;
           })
           cfg.channels;
         rolloutPolicies = cfg.rolloutPolicies;

--- a/lib/mkFleet.nix
+++ b/lib/mkFleet.nix
@@ -1,0 +1,259 @@
+{lib}: let
+  inherit (lib) mkOption types;
+
+  # --- Selector algebra (RFC-0001 §3) ---
+  selectorType = types.submodule {
+    options = {
+      tags = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = "Host has ALL listed tags.";
+      };
+      tagsAny = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = "Host has ANY listed tag.";
+      };
+      hosts = mkOption {
+        type = types.listOf types.str;
+        default = [];
+      };
+      channel = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+      };
+      all = mkOption {
+        type = types.bool;
+        default = false;
+      };
+    };
+  };
+
+  # --- Host ---
+  hostType = types.submodule {
+    options = {
+      system = mkOption {type = types.str;};
+      configuration = mkOption {
+        type = types.unspecified;
+        description = "A nixosConfiguration.";
+      };
+      tags = mkOption {
+        type = types.listOf types.str;
+        default = [];
+      };
+      channel = mkOption {type = types.str;};
+    };
+  };
+
+  tagType = types.submodule {
+    options.description = mkOption {
+      type = types.str;
+      default = "";
+    };
+  };
+
+  waveType = types.submodule {
+    options = {
+      selector = mkOption {type = selectorType;};
+      soakMinutes = mkOption {
+        type = types.int;
+        default = 0;
+      };
+    };
+  };
+
+  policyType = types.submodule {
+    options = {
+      strategy = mkOption {type = types.enum ["canary" "all-at-once" "staged"];};
+      waves = mkOption {
+        type = types.listOf waveType;
+        default = [];
+      };
+      healthGate = mkOption {
+        type = types.attrs;
+        default = {};
+      };
+      onHealthFailure = mkOption {
+        type = types.enum ["halt" "rollback-and-halt"];
+        default = "rollback-and-halt";
+      };
+    };
+  };
+
+  channelType = types.submodule {
+    options = {
+      description = mkOption {
+        type = types.str;
+        default = "";
+      };
+      rolloutPolicy = mkOption {type = types.str;};
+      reconcileIntervalMinutes = mkOption {
+        type = types.int;
+        default = 30;
+      };
+      compliance = mkOption {
+        type = types.submodule {
+          options = {
+            strict = mkOption {
+              type = types.bool;
+              default = true;
+            };
+            frameworks = mkOption {
+              type = types.listOf types.str;
+              default = [];
+            };
+          };
+        };
+        default = {};
+      };
+    };
+  };
+
+  edgeType = types.submodule {
+    options = {
+      before = mkOption {type = types.str;};
+      after = mkOption {type = types.str;};
+      reason = mkOption {
+        type = types.str;
+        default = "";
+      };
+    };
+  };
+
+  budgetType = types.submodule {
+    options = {
+      selector = mkOption {type = selectorType;};
+      maxInFlight = mkOption {
+        type = types.nullOr types.int;
+        default = null;
+      };
+      maxInFlightPct = mkOption {
+        type = types.nullOr types.int;
+        default = null;
+      };
+    };
+  };
+
+  # --- Selector resolution: selector × hosts → [host-name] ---
+  resolveSelector = sel: hosts: let
+    names = lib.attrNames hosts;
+    matches = n: let
+      h = hosts.${n};
+    in
+      sel.all
+      || (sel.hosts != [] && builtins.elem n sel.hosts)
+      || (sel.channel != null && h.channel == sel.channel)
+      || (sel.tags != [] && lib.all (t: builtins.elem t h.tags) sel.tags)
+      || (sel.tagsAny != [] && lib.any (t: builtins.elem t h.tags) sel.tagsAny);
+  in
+    builtins.filter matches names;
+
+  # --- Invariant checks (RFC-0001 §4.2) ---
+  checkInvariants = cfg: let
+    hostNames = lib.attrNames cfg.hosts;
+    channelNames = lib.attrNames cfg.channels;
+    policyNames = lib.attrNames cfg.rolloutPolicies;
+
+    hostChannelErrors =
+      lib.concatMap (
+        n:
+          lib.optional (!builtins.elem cfg.hosts.${n}.channel channelNames)
+          "host '${n}' references unknown channel '${cfg.hosts.${n}.channel}'"
+      )
+      hostNames;
+
+    channelPolicyErrors =
+      lib.concatMap (
+        n:
+          lib.optional (!builtins.elem cfg.channels.${n}.rolloutPolicy policyNames)
+          "channel '${n}' references unknown rollout policy '${cfg.channels.${n}.rolloutPolicy}'"
+      )
+      channelNames;
+
+    edgeErrors =
+      lib.concatMap (
+        e:
+          lib.optional (!builtins.elem e.before hostNames) "edge.before references unknown host '${e.before}'"
+          ++ lib.optional (!builtins.elem e.after hostNames) "edge.after references unknown host '${e.after}'"
+      )
+      cfg.edges;
+
+    errs = hostChannelErrors ++ channelPolicyErrors ++ edgeErrors;
+  in
+    if errs == []
+    then true
+    else throw ("nixfleet invariant violations:\n  - " + lib.concatStringsSep "\n  - " errs);
+
+  # --- Resolved projection (RFC-0001 §4.1) ---
+  resolveFleet = cfg:
+    assert checkInvariants cfg; {
+      schemaVersion = 1;
+      hosts =
+        lib.mapAttrs (_: h: {
+          inherit (h) system tags channel;
+          closureHash = null; # CI fills this in from h.configuration.config.system.build.toplevel
+        })
+        cfg.hosts;
+      channels =
+        lib.mapAttrs (_: c: {
+          inherit (c) rolloutPolicy reconcileIntervalMinutes compliance;
+        })
+        cfg.channels;
+      rolloutPolicies = cfg.rolloutPolicies;
+      waves =
+        lib.mapAttrs (
+          _: c:
+            map (w: {
+              hosts = resolveSelector w.selector cfg.hosts;
+              soakMinutes = w.soakMinutes;
+            })
+            cfg.rolloutPolicies.${c.rolloutPolicy}.waves
+        )
+        cfg.channels;
+      edges = cfg.edges;
+      disruptionBudgets =
+        map (b: {
+          hosts = resolveSelector b.selector cfg.hosts;
+          maxInFlight = b.maxInFlight;
+          maxInFlightPct = b.maxInFlightPct;
+        })
+        cfg.disruptionBudgets;
+    };
+in {
+  mkFleet = input: let
+    evaluated = lib.evalModules {
+      modules = [
+        {
+          options = {
+            hosts = mkOption {
+              type = types.attrsOf hostType;
+              default = {};
+            };
+            tags = mkOption {
+              type = types.attrsOf tagType;
+              default = {};
+            };
+            channels = mkOption {
+              type = types.attrsOf channelType;
+              default = {};
+            };
+            rolloutPolicies = mkOption {
+              type = types.attrsOf policyType;
+              default = {};
+            };
+            edges = mkOption {
+              type = types.listOf edgeType;
+              default = [];
+            };
+            disruptionBudgets = mkOption {
+              type = types.listOf budgetType;
+              default = [];
+            };
+          };
+        }
+        input
+      ];
+    };
+  in
+    evaluated.config // {resolved = resolveFleet evaluated.config;};
+}

--- a/lib/mkFleet.nix
+++ b/lib/mkFleet.nix
@@ -194,7 +194,17 @@
       )
       hostNames;
 
-    errs = hostChannelErrors ++ channelPolicyErrors ++ edgeErrors ++ configurationErrors;
+    complianceErrors =
+      lib.concatMap (
+        channelName: let
+          c = cfg.channels.${channelName};
+          bad = lib.filter (f: !(builtins.elem f cfg.complianceFrameworks)) c.compliance.frameworks;
+        in
+          map (f: "channel '${channelName}' references unknown compliance framework '${f}'") bad
+      )
+      (lib.attrNames cfg.channels);
+
+    errs = hostChannelErrors ++ channelPolicyErrors ++ edgeErrors ++ configurationErrors ++ complianceErrors;
   in
     if errs == []
     then true
@@ -286,6 +296,14 @@ in {
             disruptionBudgets = mkOption {
               type = types.listOf budgetType;
               default = [];
+            };
+            complianceFrameworks = mkOption {
+              type = types.listOf types.str;
+              default = ["anssi-bp028" "nis2" "dora" "iso27001"];
+              description = ''
+                Known compliance frameworks accepted by channel.compliance.frameworks.
+                Override only if using an out-of-tree compliance extension.
+              '';
             };
           };
         }

--- a/lib/mkFleet.nix
+++ b/lib/mkFleet.nix
@@ -300,10 +300,28 @@
         )
         (lib.attrNames cfg.rolloutPolicies);
 
+      budgetWarnings =
+        lib.concatMap (
+          b: let
+            hosts = resolveSelector b.selector cfg.hosts;
+            effectiveMax =
+              if b.maxInFlight != null
+              then b.maxInFlight
+              else if b.maxInFlightPct != null
+              then lib.max 1 ((builtins.length hosts * b.maxInFlightPct) / 100)
+              else builtins.length hosts;
+          in
+            lib.optional (builtins.length hosts >= 10 && effectiveMax == 1)
+            "disruption budget with maxInFlight=1 on ${toString (builtins.length hosts)} hosts will take long to complete"
+        )
+        cfg.disruptionBudgets;
+
+      allWarnings = emptySelectorWarnings ++ budgetWarnings;
+
       # Force the warnings side effect before returning the resolved value.
       # `lib.warn` prints to stderr during eval and returns its second arg.
       emittedWarnings =
-        lib.foldl' (acc: msg: lib.warn msg acc) null emptySelectorWarnings;
+        lib.foldl' (acc: msg: lib.warn msg acc) null allWarnings;
 
       resolved = {
         schemaVersion = 1;

--- a/lib/mkFleet.nix
+++ b/lib/mkFleet.nix
@@ -42,6 +42,17 @@
         default = [];
       };
       channel = mkOption {type = types.str;};
+      pubkey = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Host SSH ed25519 public key (OpenSSH format). Used by the control
+          plane to verify probe-output signatures and bind the host's mTLS
+          client cert at enrollment. `null` means the host has not been
+          enrolled yet; it appears in the fleet schema but signed artifacts
+          from it cannot be verified.
+        '';
+      };
     };
   };
 
@@ -352,9 +363,14 @@
 
       resolved = {
         schemaVersion = 1;
+        meta = {
+          schemaVersion = 1;
+          signedAt = null;
+          ciCommit = null;
+        };
         hosts =
           lib.mapAttrs (_: h: {
-            inherit (h) system tags channel;
+            inherit (h) system tags channel pubkey;
             closureHash = null; # CI fills this in from h.configuration.config.system.build.toplevel
           })
           cfg.hosts;
@@ -385,7 +401,17 @@
       };
     in
       builtins.seq emittedWarnings resolved;
+
+  withSignature = {
+    signedAt,
+    ciCommit,
+  }: resolved:
+    resolved
+    // {
+      meta = resolved.meta // {inherit signedAt ciCommit;};
+    };
 in {
+  inherit withSignature;
   mkFleet = input: let
     evaluated = lib.evalModules {
       modules = [

--- a/lib/mkFleet.nix
+++ b/lib/mkFleet.nix
@@ -178,7 +178,23 @@
       )
       cfg.edges;
 
-    errs = hostChannelErrors ++ channelPolicyErrors ++ edgeErrors;
+    configurationErrors =
+      lib.concatMap (
+        n: let
+          h = cfg.hosts.${n};
+          isValid =
+            builtins.isAttrs h.configuration
+            && h.configuration ? config
+            && h.configuration.config ? system
+            && h.configuration.config.system ? build
+            && h.configuration.config.system.build ? toplevel;
+        in
+          lib.optional (!isValid)
+          "host '${n}' configuration is not a valid nixosConfiguration (missing config.system.build.toplevel)"
+      )
+      hostNames;
+
+    errs = hostChannelErrors ++ channelPolicyErrors ++ edgeErrors ++ configurationErrors;
   in
     if errs == []
     then true

--- a/lib/mkFleet.nix
+++ b/lib/mkFleet.nix
@@ -134,6 +134,77 @@
     };
   };
 
+  # Tarjan-free cycle detection using iterative DFS marking.
+  # Edges: { after = "a"; before = "b"; } means a must finish before b starts.
+  # So we walk "after → before" edges.
+  hasCycle = edges: let
+    adj =
+      lib.foldl' (
+        acc: e: let
+          current = acc.${e.after} or [];
+        in
+          acc // {${e.after} = current ++ [e.before];}
+      ) {}
+      edges;
+    nodes = lib.unique (map (e: e.after) edges ++ map (e: e.before) edges);
+    visit = node: path: visited:
+      if builtins.elem node path
+      then {
+        cycle = true;
+        path = path ++ [node];
+        visited = visited;
+      }
+      else if builtins.elem node visited
+      then {
+        cycle = false;
+        path = path;
+        visited = visited;
+      }
+      else let
+        children = adj.${node} or [];
+        walk = c: acc:
+          if acc.cycle
+          then acc
+          else let
+            r = visit c (path ++ [node]) acc.visited;
+          in
+            if r.cycle
+            then r
+            else {
+              cycle = false;
+              path = acc.path;
+              visited = r.visited ++ [c];
+            };
+        result =
+          lib.foldl' (a: c: walk c a) {
+            cycle = false;
+            path = [];
+            visited = visited;
+          }
+          children;
+      in
+        if result.cycle
+        then result
+        else {
+          cycle = false;
+          path = [];
+          visited = result.visited ++ [node];
+        };
+    scan = nodes:
+      lib.foldl' (
+        acc: n:
+          if acc.cycle
+          then acc
+          else visit n [] acc.visited
+      ) {
+        cycle = false;
+        path = [];
+        visited = [];
+      }
+      nodes;
+  in
+    (scan nodes).cycle;
+
   # --- Selector resolution: selector × hosts → [host-name] ---
   resolveSelector = sel: hosts: let
     names = lib.attrNames hosts;
@@ -204,7 +275,9 @@
       )
       (lib.attrNames cfg.channels);
 
-    errs = hostChannelErrors ++ channelPolicyErrors ++ edgeErrors ++ configurationErrors ++ complianceErrors;
+    cycleErrors = lib.optional (hasCycle cfg.edges) "edges form a cycle; the DAG invariant is violated";
+
+    errs = hostChannelErrors ++ channelPolicyErrors ++ edgeErrors ++ configurationErrors ++ complianceErrors ++ cycleErrors;
   in
     if errs == []
     then true

--- a/lib/mkFleet.nix
+++ b/lib/mkFleet.nix
@@ -1,3 +1,9 @@
+# lib/mkFleet.nix
+#
+# Produces `fleet.resolved` per RFC-0001 §4.1 + docs/CONTRACTS.md §I #1.
+# Output is canonicalized to JCS (RFC 8785) by `bin/nixfleet-canonicalize`
+# (owned by Stream C) before signing — DO NOT introduce floats, opaque
+# derivations, or attrsets whose iteration order is significant here.
 {lib}: let
   inherit (lib) mkOption types;
 

--- a/modules/_shared/lib/default.nix
+++ b/modules/_shared/lib/default.nix
@@ -2,7 +2,10 @@
 {
   inputs,
   lib,
-}: {
+}: let
+  mkFleetImpl = import ../../../lib/mkFleet.nix {inherit lib;};
+in {
   mkHost = import ./mk-host.nix {inherit inputs lib;};
   mkVmApps = import ./mk-vm-apps.nix {inherit inputs;};
+  inherit (mkFleetImpl) mkFleet withSignature;
 }

--- a/modules/_trust.nix
+++ b/modules/_trust.nix
@@ -1,4 +1,4 @@
-# modules/trust.nix
+# modules/_trust.nix
 #
 # nixfleet.trust.* — the four trust roots from docs/CONTRACTS.md §II.
 # Public keys are declared here; private keys live elsewhere (HSM, host
@@ -6,11 +6,84 @@
 #
 # Each root supports a `.previous` slot for the 30-day rotation grace
 # window and a shared `rejectBefore` timestamp for compromise response.
+#
+# `ciReleaseKey` carries an explicit `algorithm` per the §II #1 amendment
+# in abstracts33d/nixfleet#18 (ECDSA P-256 alongside ed25519 because
+# commodity TPM2 hardware does not expose the ed25519 curve). The other
+# trust roots remain bare strings for now; their algorithms are pinned
+# by CONTRACTS.md §II #2 (attic-native) and §II #3 (ed25519).
 {
   config,
   lib,
   ...
 }: let
+  # Typed public-key declaration (CONTRACTS §II #1 amendment).
+  # Consumers read `.algorithm` to pick the verifier; `.public` is the
+  # base64-encoded raw public key bytes per the algorithm's encoding rule.
+  publicKeyType = lib.types.submodule {
+    options = {
+      algorithm = lib.mkOption {
+        type = lib.types.enum ["ed25519" "ecdsa-p256"];
+        description = ''
+          Signing algorithm. `ed25519` is the preferred default for
+          HSMs, YubiKeys, cloud KMS, and software-held keys. `ecdsa-p256`
+          exists because commodity TPM2 hardware (Intel PTT, AMD fTPM)
+          does not expose the ed25519 curve (TPM2_ECC_CURVE_ED25519 =
+          0x0040 is rarely implemented). Both produce 64-byte signatures.
+        '';
+      };
+      public = lib.mkOption {
+        type = lib.types.str;
+        description = ''
+          Base64-encoded raw public key bytes.
+          - `ed25519` — 32-byte raw pubkey.
+          - `ecdsa-p256` — uncompressed point, 64 bytes (`X ‖ Y`, no
+            `0x04` prefix). Consumers convert to SEC1 / DER SPKI at
+            verify time.
+        '';
+      };
+    };
+  };
+
+  # CI-release-key slot. Per CONTRACTS §II #1, the public half is typed
+  # (algorithm + public) so consumers learn the algorithm without
+  # out-of-band knowledge. `rejectBefore` remains a flat timestamp.
+  ciReleaseKeySlotType = lib.types.submodule {
+    options = {
+      current = lib.mkOption {
+        type = lib.types.nullOr publicKeyType;
+        default = null;
+        description = ''
+          Current CI release public key. Set to `null` means no key is
+          pinned yet — artifact verification will refuse all signatures.
+        '';
+      };
+      previous = lib.mkOption {
+        type = lib.types.nullOr publicKeyType;
+        default = null;
+        description = ''
+          Previous CI release public key accepted during the 30-day
+          rotation grace window (CONTRACTS §II #1 rotation procedure).
+          May differ in algorithm from `current` — consumers accept
+          signatures under either algorithm during the overlap. Remove
+          when the window closes.
+        '';
+      };
+      rejectBefore = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          RFC 3339 timestamp. Signed artifacts older than this are refused
+          regardless of key. Used in compromise response when rolling out
+          a new key is not sufficient (pre-compromise artifacts still
+          carry the old key's trust).
+        '';
+      };
+    };
+  };
+
+  # Legacy slot type — bare-string current/previous, used by the other
+  # two trust roots that still pin a single algorithm per CONTRACTS §II.
   keySlotType = lib.types.submodule {
     options = {
       current = lib.mkOption {
@@ -42,12 +115,13 @@
 in {
   options.nixfleet.trust = {
     ciReleaseKey = lib.mkOption {
-      type = keySlotType;
+      type = ciReleaseKeySlotType;
       default = {};
       description = ''
-        CI release key (ed25519). Private half in Stream A's HSM/TPM;
-        public half declared here. Verified by the control plane on every
-        `fleet.resolved` fetch. See docs/CONTRACTS.md §II #1.
+        CI release key. Private half in Stream A's HSM/TPM; public half
+        declared here as a typed submodule (`algorithm` + `public`) per
+        CONTRACTS.md §II #1. Verified by the control plane on every
+        `fleet.resolved` fetch, matching `meta.signatureAlgorithm`.
       '';
     };
 

--- a/modules/_trust.nix
+++ b/modules/_trust.nix
@@ -1,0 +1,97 @@
+# modules/trust.nix
+#
+# nixfleet.trust.* — the four trust roots from docs/CONTRACTS.md §II.
+# Public keys are declared here; private keys live elsewhere (HSM, host
+# SSH key, offline Yubikey) and never enter this module.
+#
+# Each root supports a `.previous` slot for the 30-day rotation grace
+# window and a shared `rejectBefore` timestamp for compromise response.
+{
+  config,
+  lib,
+  ...
+}: let
+  keySlotType = lib.types.submodule {
+    options = {
+      current = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "Current public key (OpenSSH-armored or framework-specific format).";
+      };
+      previous = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          Previous public key accepted during rotation grace. Remove after
+          the rotation window closes (see docs/CONTRACTS.md §II for
+          per-key grace windows).
+        '';
+      };
+      rejectBefore = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          RFC 3339 timestamp. Signed artifacts older than this are refused
+          regardless of key. Used in compromise response when rolling out
+          a new key is not sufficient (pre-compromise artifacts still
+          carry the old key's trust).
+        '';
+      };
+    };
+  };
+in {
+  options.nixfleet.trust = {
+    ciReleaseKey = lib.mkOption {
+      type = keySlotType;
+      default = {};
+      description = ''
+        CI release key (ed25519). Private half in Stream A's HSM/TPM;
+        public half declared here. Verified by the control plane on every
+        `fleet.resolved` fetch. See docs/CONTRACTS.md §II #1.
+      '';
+    };
+
+    atticCacheKey = lib.mkOption {
+      type = keySlotType;
+      default = {};
+      description = ''
+        Attic binary-cache key. Agents verify before every closure
+        activation. See docs/CONTRACTS.md §II #2.
+      '';
+    };
+
+    orgRootKey = lib.mkOption {
+      type = keySlotType;
+      default = {};
+      description = ''
+        Organization root key. Verifies enrollment tokens at the control
+        plane. Rotation is a catastrophic event — see docs/CONTRACTS.md
+        §II #3.
+      '';
+    };
+  };
+
+  config.assertions = [
+    {
+      assertion =
+        config.nixfleet.trust.ciReleaseKey.previous
+        == null
+        || config.nixfleet.trust.ciReleaseKey.current != null;
+      message = "nixfleet.trust.ciReleaseKey: cannot set .previous without .current";
+    }
+    {
+      assertion =
+        config.nixfleet.trust.atticCacheKey.previous
+        == null
+        || config.nixfleet.trust.atticCacheKey.current != null;
+      message = "nixfleet.trust.atticCacheKey: cannot set .previous without .current";
+    }
+    {
+      assertion =
+        config.nixfleet.trust.orgRootKey.previous
+        == null
+        || config.nixfleet.trust.orgRootKey.current != null;
+      message = "nixfleet.trust.orgRootKey: cannot set .previous without .current";
+    }
+  ];
+}

--- a/modules/core/_nixos.nix
+++ b/modules/core/_nixos.nix
@@ -26,6 +26,8 @@
 }: let
   hS = config.hostSpec;
 in {
+  imports = [../_trust.nix];
+
   # --- nixpkgs ---
   nixpkgs.config = lib.mkDefault {
     allowUnfree = true;

--- a/modules/flake-module.nix
+++ b/modules/flake-module.nix
@@ -14,6 +14,8 @@
 }: let
   nixfleetLib = import ./_shared/lib/default.nix {inherit inputs lib;};
 in {
+  imports = [../lib/flake-module.nix];
+
   options.nixfleet.lib = lib.mkOption {
     type = lib.types.attrs;
     default = nixfleetLib;

--- a/modules/flake-module.nix
+++ b/modules/flake-module.nix
@@ -14,8 +14,6 @@
 }: let
   nixfleetLib = import ./_shared/lib/default.nix {inherit inputs lib;};
 in {
-  imports = [../lib/flake-module.nix];
-
   options.nixfleet.lib = lib.mkOption {
     type = lib.types.attrs;
     default = nixfleetLib;

--- a/modules/tests/_trust-options.nix
+++ b/modules/tests/_trust-options.nix
@@ -1,0 +1,28 @@
+# modules/tests/trust-options.nix
+#
+# Eval test for modules/trust.nix. Verifies the option tree shape.
+{
+  lib,
+  pkgs,
+  ...
+}: let
+  happy =
+    (lib.evalModules {
+      modules = [
+        ../_trust.nix
+        {
+          nixfleet.trust = {
+            ciReleaseKey.current = "ssh-ed25519 AAAA...ci";
+            atticCacheKey.current = "attic:cache.example.com:AAAA...";
+          };
+        }
+      ];
+      specialArgs = {inherit pkgs;};
+    })
+    .config;
+in {
+  happyCiKey = happy.nixfleet.trust.ciReleaseKey.current;
+  happyAtticKey = happy.nixfleet.trust.atticCacheKey.current;
+  happyOrgKeyDefaultsToNull = happy.nixfleet.trust.orgRootKey.current;
+  assertionsDeclared = builtins.length happy.assertions;
+}

--- a/modules/tests/_trust-options.nix
+++ b/modules/tests/_trust-options.nix
@@ -1,6 +1,12 @@
-# modules/tests/trust-options.nix
+# modules/tests/_trust-options.nix
 #
-# Eval test for modules/trust.nix. Verifies the option tree shape.
+# Eval test for modules/_trust.nix. Verifies the option tree shape,
+# including the typed ciReleaseKey submodule per CONTRACTS §II #1.
+#
+# Declares `assertions` as a freeform option so the _trust.nix
+# assertions (which target the full NixOS module system at host build
+# time) can be materialized here in a bare lib.evalModules context
+# without a missing-option error.
 {
   lib,
   pkgs,
@@ -11,8 +17,17 @@
       modules = [
         ../_trust.nix
         {
+          options.assertions = lib.mkOption {
+            type = lib.types.listOf lib.types.unspecified;
+            default = [];
+          };
+        }
+        {
           nixfleet.trust = {
-            ciReleaseKey.current = "ssh-ed25519 AAAA...ci";
+            ciReleaseKey.current = {
+              algorithm = "ecdsa-p256";
+              public = "AAAAcdsap256placeholderbase64bytesXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+            };
             atticCacheKey.current = "attic:cache.example.com:AAAA...";
           };
         }
@@ -21,7 +36,8 @@
     })
     .config;
 in {
-  happyCiKey = happy.nixfleet.trust.ciReleaseKey.current;
+  happyCiKeyAlgorithm = happy.nixfleet.trust.ciReleaseKey.current.algorithm;
+  happyCiKeyPublicNonEmpty = (builtins.stringLength happy.nixfleet.trust.ciReleaseKey.current.public) > 0;
   happyAtticKey = happy.nixfleet.trust.atticCacheKey.current;
   happyOrgKeyDefaultsToNull = happy.nixfleet.trust.orgRootKey.current;
   assertionsDeclared = builtins.length happy.assertions;

--- a/modules/tests/eval.nix
+++ b/modules/tests/eval.nix
@@ -18,6 +18,28 @@
   in
     lib.optionalAttrs (system == "x86_64-linux") {
       checks = {
+        # --- lib/mkFleet: eval-only harness (positive + negative fixtures) ---
+        # Evaluates every fixture under tests/lib/mkFleet/{fixtures,negative}.
+        # Positive fixtures compare against golden .resolved.json files;
+        # negative fixtures are expected to throw. Each entry in `results`
+        # must be the literal string "ok" - anything else fails the check.
+        mkFleet-eval-tests = let
+          harness = import ../../tests/lib/mkFleet {inherit lib;};
+          results = harness.results;
+          allOk = lib.all (r: r == "ok") results;
+        in
+          pkgs.runCommand "mkFleet-eval-tests" {} (
+            if allOk
+            then ''
+              echo "PASS: mkFleet harness — ${toString (builtins.length results)} fixtures ok"
+              printf '%s\n' ${lib.concatMapStringsSep " " (r: ''"${r}"'') results} > $out
+            ''
+            else ''
+              echo "FAIL: mkFleet harness produced non-ok results: ${builtins.toJSON results}" >&2
+              exit 1
+            ''
+          );
+
         # --- SSH hardening (core/nixos.nix) ---
         eval-ssh-hardening = let
           cfg = nixosCfg "web-02";

--- a/tests/lib/mkFleet/default.nix
+++ b/tests/lib/mkFleet/default.nix
@@ -31,7 +31,7 @@
     else "ok";
 
   listFixtures = dir:
-    lib.filter (n: lib.hasSuffix ".nix" n) (builtins.attrNames (builtins.readDir dir));
+    lib.filter (n: lib.hasSuffix ".nix" n && !(lib.hasPrefix "_" n)) (builtins.attrNames (builtins.readDir dir));
 
   positives = map (n: runPositive (./fixtures + "/${n}")) (listFixtures ./fixtures);
   negatives = map (n: runNegative (./negative + "/${n}")) (listFixtures ./negative);

--- a/tests/lib/mkFleet/default.nix
+++ b/tests/lib/mkFleet/default.nix
@@ -9,7 +9,7 @@
 }: let
   runPositive = path: let
     cfg = import path {inherit lib mkFleet;};
-    expectedPath = lib.replaceStrings [".nix"] [".resolved.json"] path;
+    expectedPath = lib.replaceStrings [".nix"] [".resolved.json"] (toString path);
     expected = builtins.fromJSON (builtins.readFile expectedPath);
     actual = cfg.resolved;
     match = builtins.toJSON actual == builtins.toJSON expected;

--- a/tests/lib/mkFleet/default.nix
+++ b/tests/lib/mkFleet/default.nix
@@ -1,0 +1,40 @@
+# tests/lib/mkFleet/default.nix
+#
+# Eval-only tests for lib/mkFleet.nix. No VM, no build — pure evaluation.
+# Each .nix file under ./fixtures/ is a positive scenario (must eval clean).
+# Each .nix file under ./negative/ is expected to `throw` a specific error.
+{
+  lib,
+  mkFleet ? (import ../../../lib/mkFleet.nix {inherit lib;}).mkFleet,
+}: let
+  runPositive = path: let
+    cfg = import path {inherit lib mkFleet;};
+    expectedPath = lib.replaceStrings [".nix"] [".resolved.json"] path;
+    expected = builtins.fromJSON (builtins.readFile expectedPath);
+    actual = cfg.resolved;
+    match = builtins.toJSON actual == builtins.toJSON expected;
+  in
+    if match
+    then "ok"
+    else
+      throw ''
+        golden mismatch for ${toString path}
+        expected: ${builtins.toJSON expected}
+        actual:   ${builtins.toJSON actual}
+      '';
+
+  runNegative = path: let
+    result = builtins.tryEval (import path {inherit lib mkFleet;}).resolved;
+  in
+    if result.success
+    then throw "expected eval failure for ${toString path}, got success"
+    else "ok";
+
+  listFixtures = dir:
+    lib.filter (n: lib.hasSuffix ".nix" n) (builtins.attrNames (builtins.readDir dir));
+
+  positives = map (n: runPositive (./fixtures + "/${n}")) (listFixtures ./fixtures);
+  negatives = map (n: runNegative (./negative + "/${n}")) (listFixtures ./negative);
+in {
+  results = positives ++ negatives;
+}

--- a/tests/lib/mkFleet/fixtures/_stub-configuration.nix
+++ b/tests/lib/mkFleet/fixtures/_stub-configuration.nix
@@ -1,0 +1,10 @@
+# tests/lib/mkFleet/fixtures/_stub-configuration.nix
+#
+# Minimal stub that looks like a nixosConfiguration enough to satisfy
+# the `host.configuration` invariant without needing to evaluate NixOS.
+{}: {
+  config.system.build.toplevel = {
+    outPath = "/nix/store/0000000000000000000000000000000000000000-stub";
+    drvPath = "/nix/store/0000000000000000000000000000000000000000-stub.drv";
+  };
+}

--- a/tests/lib/mkFleet/fixtures/empty-selector-warns.nix
+++ b/tests/lib/mkFleet/fixtures/empty-selector-warns.nix
@@ -8,6 +8,8 @@ mkFleet {
   };
   channels.stable = {
     rolloutPolicy = "emptyish";
+    signingIntervalMinutes = 60;
+    freshnessWindow = 180;
   };
   rolloutPolicies.emptyish = {
     strategy = "canary";

--- a/tests/lib/mkFleet/fixtures/empty-selector-warns.nix
+++ b/tests/lib/mkFleet/fixtures/empty-selector-warns.nix
@@ -1,0 +1,25 @@
+{mkFleet, ...}:
+mkFleet {
+  hosts.m = {
+    system = "x86_64-linux";
+    configuration = import ./_stub-configuration.nix {};
+    tags = ["role-a"];
+    channel = "stable";
+  };
+  channels.stable = {
+    rolloutPolicy = "emptyish";
+  };
+  rolloutPolicies.emptyish = {
+    strategy = "canary";
+    waves = [
+      {
+        selector.tags = ["role-b"];
+        soakMinutes = 10;
+      } # resolves to zero hosts — warning expected
+      {
+        selector.all = true;
+        soakMinutes = 0;
+      }
+    ];
+  };
+}

--- a/tests/lib/mkFleet/fixtures/empty-selector-warns.resolved.json
+++ b/tests/lib/mkFleet/fixtures/empty-selector-warns.resolved.json
@@ -1,0 +1,64 @@
+{
+  "channels": {
+    "stable": {
+      "compliance": {
+        "frameworks": [],
+        "strict": true
+      },
+      "reconcileIntervalMinutes": 30,
+      "rolloutPolicy": "emptyish"
+    }
+  },
+  "disruptionBudgets": [],
+  "edges": [],
+  "hosts": {
+    "m": {
+      "channel": "stable",
+      "closureHash": null,
+      "system": "x86_64-linux",
+      "tags": ["role-a"]
+    }
+  },
+  "rolloutPolicies": {
+    "emptyish": {
+      "healthGate": {},
+      "onHealthFailure": "rollback-and-halt",
+      "strategy": "canary",
+      "waves": [
+        {
+          "selector": {
+            "all": false,
+            "channel": null,
+            "hosts": [],
+            "tags": ["role-b"],
+            "tagsAny": []
+          },
+          "soakMinutes": 10
+        },
+        {
+          "selector": {
+            "all": true,
+            "channel": null,
+            "hosts": [],
+            "tags": [],
+            "tagsAny": []
+          },
+          "soakMinutes": 0
+        }
+      ]
+    }
+  },
+  "schemaVersion": 1,
+  "waves": {
+    "stable": [
+      {
+        "hosts": [],
+        "soakMinutes": 10
+      },
+      {
+        "hosts": ["m"],
+        "soakMinutes": 0
+      }
+    ]
+  }
+}

--- a/tests/lib/mkFleet/fixtures/empty-selector-warns.resolved.json
+++ b/tests/lib/mkFleet/fixtures/empty-selector-warns.resolved.json
@@ -5,8 +5,10 @@
         "frameworks": [],
         "strict": true
       },
+      "freshnessWindow": 180,
       "reconcileIntervalMinutes": 30,
-      "rolloutPolicy": "emptyish"
+      "rolloutPolicy": "emptyish",
+      "signingIntervalMinutes": 60
     }
   },
   "disruptionBudgets": [],

--- a/tests/lib/mkFleet/fixtures/empty-selector-warns.resolved.json
+++ b/tests/lib/mkFleet/fixtures/empty-selector-warns.resolved.json
@@ -17,9 +17,15 @@
     "m": {
       "channel": "stable",
       "closureHash": null,
+      "pubkey": null,
       "system": "x86_64-linux",
       "tags": ["role-a"]
     }
+  },
+  "meta": {
+    "ciCommit": null,
+    "schemaVersion": 1,
+    "signedAt": null
   },
   "rolloutPolicies": {
     "emptyish": {

--- a/tests/lib/mkFleet/fixtures/homelab.nix
+++ b/tests/lib/mkFleet/fixtures/homelab.nix
@@ -1,0 +1,18 @@
+# tests/lib/mkFleet/fixtures/homelab.nix
+#
+# Acceptance fixture: imports examples/fleet-homelab/fleet.nix with stub
+# nixosConfigurations. Pinned golden at homelab.resolved.json proves the
+# homelab example produces a schemaVersion:1 artifact matching RFC-0001 §4.1.
+{mkFleet, ...}: let
+  stub = import ./_stub-configuration.nix {};
+in
+  import ../../../../examples/fleet-homelab/fleet.nix {
+    self = {
+      nixosConfigurations = {
+        m70q-attic = stub;
+        workstation = stub;
+        rpi-sensor-01 = stub;
+      };
+    };
+    nixfleet.lib.mkFleet = mkFleet;
+  }

--- a/tests/lib/mkFleet/fixtures/homelab.resolved.json
+++ b/tests/lib/mkFleet/fixtures/homelab.resolved.json
@@ -1,0 +1,138 @@
+{
+  "channels": {
+    "edge-slow": {
+      "compliance": {
+        "frameworks": [],
+        "strict": true
+      },
+      "freshnessWindow": 20160,
+      "reconcileIntervalMinutes": 10080,
+      "rolloutPolicy": "all-at-once",
+      "signingIntervalMinutes": 60
+    },
+    "stable": {
+      "compliance": {
+        "frameworks": ["anssi-bp028"],
+        "strict": true
+      },
+      "freshnessWindow": 180,
+      "reconcileIntervalMinutes": 30,
+      "rolloutPolicy": "homelab-canary",
+      "signingIntervalMinutes": 60
+    }
+  },
+  "disruptionBudgets": [
+    {
+      "hosts": ["m70q-attic"],
+      "maxInFlight": 1,
+      "maxInFlightPct": null
+    },
+    {
+      "hosts": ["m70q-attic"],
+      "maxInFlight": 1,
+      "maxInFlightPct": null
+    }
+  ],
+  "edges": [],
+  "hosts": {
+    "m70q-attic": {
+      "channel": "stable",
+      "closureHash": null,
+      "pubkey": null,
+      "system": "x86_64-linux",
+      "tags": ["homelab", "always-on", "eu-fr", "server", "coordinator"]
+    },
+    "rpi-sensor-01": {
+      "channel": "edge-slow",
+      "closureHash": null,
+      "pubkey": null,
+      "system": "aarch64-linux",
+      "tags": ["edge", "eu-fr", "sensor", "low-power"]
+    },
+    "workstation": {
+      "channel": "stable",
+      "closureHash": null,
+      "pubkey": null,
+      "system": "x86_64-linux",
+      "tags": ["homelab", "eu-fr", "workstation", "builder"]
+    }
+  },
+  "meta": {
+    "ciCommit": null,
+    "schemaVersion": 1,
+    "signedAt": null
+  },
+  "rolloutPolicies": {
+    "all-at-once": {
+      "healthGate": {
+        "systemdFailedUnits": {
+          "max": 0
+        }
+      },
+      "onHealthFailure": "rollback-and-halt",
+      "strategy": "all-at-once",
+      "waves": [
+        {
+          "selector": {
+            "all": true,
+            "channel": null,
+            "hosts": [],
+            "tags": [],
+            "tagsAny": []
+          },
+          "soakMinutes": 0
+        }
+      ]
+    },
+    "homelab-canary": {
+      "healthGate": {
+        "systemdFailedUnits": {
+          "max": 0
+        }
+      },
+      "onHealthFailure": "rollback-and-halt",
+      "strategy": "canary",
+      "waves": [
+        {
+          "selector": {
+            "all": false,
+            "channel": null,
+            "hosts": [],
+            "tags": ["workstation"],
+            "tagsAny": []
+          },
+          "soakMinutes": 30
+        },
+        {
+          "selector": {
+            "all": false,
+            "channel": null,
+            "hosts": [],
+            "tags": ["always-on"],
+            "tagsAny": []
+          },
+          "soakMinutes": 60
+        }
+      ]
+    }
+  },
+  "schemaVersion": 1,
+  "waves": {
+    "edge-slow": [
+      {
+        "hosts": ["m70q-attic", "rpi-sensor-01", "workstation"],
+        "soakMinutes": 0
+      }
+    ],
+    "stable": [
+      {
+        "hosts": ["workstation"],
+        "soakMinutes": 30
+      },
+      {
+        "hosts": ["m70q-attic"],
+        "soakMinutes": 60
+      }
+    ]
+  }
+}

--- a/tests/lib/mkFleet/fixtures/tight-budget-warns.nix
+++ b/tests/lib/mkFleet/fixtures/tight-budget-warns.nix
@@ -15,6 +15,8 @@ in
     hosts = lib.genAttrs (map (n: "host-${toString n}") (lib.range 1 10)) (_: mkStubHost "etcd");
     channels.stable = {
       rolloutPolicy = "all-at-once";
+      signingIntervalMinutes = 60;
+      freshnessWindow = 180;
     };
     rolloutPolicies.all-at-once = {
       strategy = "all-at-once";

--- a/tests/lib/mkFleet/fixtures/tight-budget-warns.nix
+++ b/tests/lib/mkFleet/fixtures/tight-budget-warns.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  mkFleet,
+  ...
+}: let
+  stub = import ./_stub-configuration.nix {};
+  mkStubHost = tag: {
+    system = "x86_64-linux";
+    configuration = stub;
+    tags = [tag];
+    channel = "stable";
+  };
+in
+  mkFleet {
+    hosts = lib.genAttrs (map (n: "host-${toString n}") (lib.range 1 10)) (_: mkStubHost "etcd");
+    channels.stable = {
+      rolloutPolicy = "all-at-once";
+    };
+    rolloutPolicies.all-at-once = {
+      strategy = "all-at-once";
+      waves = [
+        {
+          selector.all = true;
+          soakMinutes = 0;
+        }
+      ];
+    };
+    disruptionBudgets = [
+      {
+        selector.tags = ["etcd"];
+        maxInFlight = 1;
+      }
+    ];
+  }

--- a/tests/lib/mkFleet/fixtures/tight-budget-warns.resolved.json
+++ b/tests/lib/mkFleet/fixtures/tight-budget-warns.resolved.json
@@ -34,63 +34,78 @@
     "host-1": {
       "channel": "stable",
       "closureHash": null,
+      "pubkey": null,
       "system": "x86_64-linux",
       "tags": ["etcd"]
     },
     "host-10": {
       "channel": "stable",
       "closureHash": null,
+      "pubkey": null,
       "system": "x86_64-linux",
       "tags": ["etcd"]
     },
     "host-2": {
       "channel": "stable",
       "closureHash": null,
+      "pubkey": null,
       "system": "x86_64-linux",
       "tags": ["etcd"]
     },
     "host-3": {
       "channel": "stable",
       "closureHash": null,
+      "pubkey": null,
       "system": "x86_64-linux",
       "tags": ["etcd"]
     },
     "host-4": {
       "channel": "stable",
       "closureHash": null,
+      "pubkey": null,
       "system": "x86_64-linux",
       "tags": ["etcd"]
     },
     "host-5": {
       "channel": "stable",
       "closureHash": null,
+      "pubkey": null,
       "system": "x86_64-linux",
       "tags": ["etcd"]
     },
     "host-6": {
       "channel": "stable",
       "closureHash": null,
+      "pubkey": null,
       "system": "x86_64-linux",
       "tags": ["etcd"]
     },
     "host-7": {
       "channel": "stable",
       "closureHash": null,
+      "pubkey": null,
       "system": "x86_64-linux",
       "tags": ["etcd"]
     },
     "host-8": {
       "channel": "stable",
       "closureHash": null,
+      "pubkey": null,
       "system": "x86_64-linux",
       "tags": ["etcd"]
     },
     "host-9": {
       "channel": "stable",
       "closureHash": null,
+      "pubkey": null,
       "system": "x86_64-linux",
       "tags": ["etcd"]
     }
+  },
+  "meta": {
+    "ciCommit": null,
+    "schemaVersion": 1,
+    "signedAt": null
   },
   "rolloutPolicies": {
     "all-at-once": {

--- a/tests/lib/mkFleet/fixtures/tight-budget-warns.resolved.json
+++ b/tests/lib/mkFleet/fixtures/tight-budget-warns.resolved.json
@@ -1,0 +1,132 @@
+{
+  "channels": {
+    "stable": {
+      "compliance": {
+        "frameworks": [],
+        "strict": true
+      },
+      "reconcileIntervalMinutes": 30,
+      "rolloutPolicy": "all-at-once"
+    }
+  },
+  "disruptionBudgets": [
+    {
+      "hosts": [
+        "host-1",
+        "host-10",
+        "host-2",
+        "host-3",
+        "host-4",
+        "host-5",
+        "host-6",
+        "host-7",
+        "host-8",
+        "host-9"
+      ],
+      "maxInFlight": 1,
+      "maxInFlightPct": null
+    }
+  ],
+  "edges": [],
+  "hosts": {
+    "host-1": {
+      "channel": "stable",
+      "closureHash": null,
+      "system": "x86_64-linux",
+      "tags": ["etcd"]
+    },
+    "host-10": {
+      "channel": "stable",
+      "closureHash": null,
+      "system": "x86_64-linux",
+      "tags": ["etcd"]
+    },
+    "host-2": {
+      "channel": "stable",
+      "closureHash": null,
+      "system": "x86_64-linux",
+      "tags": ["etcd"]
+    },
+    "host-3": {
+      "channel": "stable",
+      "closureHash": null,
+      "system": "x86_64-linux",
+      "tags": ["etcd"]
+    },
+    "host-4": {
+      "channel": "stable",
+      "closureHash": null,
+      "system": "x86_64-linux",
+      "tags": ["etcd"]
+    },
+    "host-5": {
+      "channel": "stable",
+      "closureHash": null,
+      "system": "x86_64-linux",
+      "tags": ["etcd"]
+    },
+    "host-6": {
+      "channel": "stable",
+      "closureHash": null,
+      "system": "x86_64-linux",
+      "tags": ["etcd"]
+    },
+    "host-7": {
+      "channel": "stable",
+      "closureHash": null,
+      "system": "x86_64-linux",
+      "tags": ["etcd"]
+    },
+    "host-8": {
+      "channel": "stable",
+      "closureHash": null,
+      "system": "x86_64-linux",
+      "tags": ["etcd"]
+    },
+    "host-9": {
+      "channel": "stable",
+      "closureHash": null,
+      "system": "x86_64-linux",
+      "tags": ["etcd"]
+    }
+  },
+  "rolloutPolicies": {
+    "all-at-once": {
+      "healthGate": {},
+      "onHealthFailure": "rollback-and-halt",
+      "strategy": "all-at-once",
+      "waves": [
+        {
+          "selector": {
+            "all": true,
+            "channel": null,
+            "hosts": [],
+            "tags": [],
+            "tagsAny": []
+          },
+          "soakMinutes": 0
+        }
+      ]
+    }
+  },
+  "schemaVersion": 1,
+  "waves": {
+    "stable": [
+      {
+        "hosts": [
+          "host-1",
+          "host-10",
+          "host-2",
+          "host-3",
+          "host-4",
+          "host-5",
+          "host-6",
+          "host-7",
+          "host-8",
+          "host-9"
+        ],
+        "soakMinutes": 0
+      }
+    ]
+  }
+}

--- a/tests/lib/mkFleet/fixtures/tight-budget-warns.resolved.json
+++ b/tests/lib/mkFleet/fixtures/tight-budget-warns.resolved.json
@@ -5,8 +5,10 @@
         "frameworks": [],
         "strict": true
       },
+      "freshnessWindow": 180,
       "reconcileIntervalMinutes": 30,
-      "rolloutPolicy": "all-at-once"
+      "rolloutPolicy": "all-at-once",
+      "signingIntervalMinutes": 60
     }
   },
   "disruptionBudgets": [

--- a/tests/lib/mkFleet/negative/edge-cycle.nix
+++ b/tests/lib/mkFleet/negative/edge-cycle.nix
@@ -18,6 +18,8 @@ in
     };
     channels.stable = {
       rolloutPolicy = "all-at-once";
+      signingIntervalMinutes = 60;
+      freshnessWindow = 180;
     };
     rolloutPolicies.all-at-once = {
       strategy = "all-at-once";

--- a/tests/lib/mkFleet/negative/edge-cycle.nix
+++ b/tests/lib/mkFleet/negative/edge-cycle.nix
@@ -1,0 +1,43 @@
+{mkFleet, ...}: let
+  stub = import ../fixtures/_stub-configuration.nix {};
+in
+  mkFleet {
+    hosts = {
+      a = {
+        system = "x86_64-linux";
+        configuration = stub;
+        tags = [];
+        channel = "stable";
+      };
+      b = {
+        system = "x86_64-linux";
+        configuration = stub;
+        tags = [];
+        channel = "stable";
+      };
+    };
+    channels.stable = {
+      rolloutPolicy = "all-at-once";
+    };
+    rolloutPolicies.all-at-once = {
+      strategy = "all-at-once";
+      waves = [
+        {
+          selector.all = true;
+          soakMinutes = 0;
+        }
+      ];
+    };
+    edges = [
+      {
+        after = "a";
+        before = "b";
+        reason = "a before b";
+      }
+      {
+        after = "b";
+        before = "a";
+        reason = "cycle!";
+      }
+    ];
+  }

--- a/tests/lib/mkFleet/negative/freshness-below-2x.nix
+++ b/tests/lib/mkFleet/negative/freshness-below-2x.nix
@@ -1,0 +1,25 @@
+{mkFleet, ...}: let
+  stub = import ../fixtures/_stub-configuration.nix {};
+in
+  mkFleet {
+    hosts.m = {
+      system = "x86_64-linux";
+      configuration = stub;
+      tags = [];
+      channel = "stable";
+    };
+    channels.stable = {
+      rolloutPolicy = "all-at-once";
+      signingIntervalMinutes = 60;
+      freshnessWindow = 90; # < 2 × 60, must fail
+    };
+    rolloutPolicies.all-at-once = {
+      strategy = "all-at-once";
+      waves = [
+        {
+          selector.all = true;
+          soakMinutes = 0;
+        }
+      ];
+    };
+  }

--- a/tests/lib/mkFleet/negative/host-bad-configuration.nix
+++ b/tests/lib/mkFleet/negative/host-bad-configuration.nix
@@ -1,0 +1,21 @@
+{mkFleet, ...}:
+mkFleet {
+  hosts.bad = {
+    system = "x86_64-linux";
+    configuration = "not-a-nixos-config";
+    tags = [];
+    channel = "stable";
+  };
+  channels.stable = {
+    rolloutPolicy = "all-at-once";
+  };
+  rolloutPolicies.all-at-once = {
+    strategy = "all-at-once";
+    waves = [
+      {
+        selector.all = true;
+        soakMinutes = 0;
+      }
+    ];
+  };
+}

--- a/tests/lib/mkFleet/negative/host-bad-configuration.nix
+++ b/tests/lib/mkFleet/negative/host-bad-configuration.nix
@@ -8,6 +8,8 @@ mkFleet {
   };
   channels.stable = {
     rolloutPolicy = "all-at-once";
+    signingIntervalMinutes = 60;
+    freshnessWindow = 180;
   };
   rolloutPolicies.all-at-once = {
     strategy = "all-at-once";

--- a/tests/lib/mkFleet/negative/unknown-framework.nix
+++ b/tests/lib/mkFleet/negative/unknown-framework.nix
@@ -1,0 +1,22 @@
+{mkFleet, ...}:
+mkFleet {
+  hosts.m = {
+    system = "x86_64-linux";
+    configuration = import ../fixtures/_stub-configuration.nix {};
+    tags = [];
+    channel = "stable";
+  };
+  channels.stable = {
+    rolloutPolicy = "all-at-once";
+    compliance.frameworks = ["fictional-framework/v99"];
+  };
+  rolloutPolicies.all-at-once = {
+    strategy = "all-at-once";
+    waves = [
+      {
+        selector.all = true;
+        soakMinutes = 0;
+      }
+    ];
+  };
+}

--- a/tests/lib/mkFleet/negative/unknown-framework.nix
+++ b/tests/lib/mkFleet/negative/unknown-framework.nix
@@ -8,6 +8,8 @@ mkFleet {
   };
   channels.stable = {
     rolloutPolicy = "all-at-once";
+    signingIntervalMinutes = 60;
+    freshnessWindow = 180;
     compliance.frameworks = ["fictional-framework/v99"];
   };
   rolloutPolicies.all-at-once = {


### PR DESCRIPTION
**Draft.** Tasks 13-16 (golden-file acceptance test, CONTRACTS.md edit, CHANGELOG/README, CI wiring) land as follow-up commits on this branch before the PR is marked ready.

## Summary

Promotes the `spike/lib/mkFleet.nix` prototype to production `lib/mkFleet.nix` with every RFC-0001 §4.2 invariant enforced, adds the `nixfleet.trust.*` option tree for the four trust roots from `docs/CONTRACTS.md §II`, and wires an end-to-end homelab example exercising every new field.

Closes #1. Lands the Nix portion of #12 (signing-related option tree).

## What's new

- **`lib/mkFleet.nix`** — production mkFleet with every RFC-0001 §4.2 invariant:
  - Host/channel/policy reference checks (from spike)
  - Host `configuration` validity (`config.system.build.toplevel` existence)
  - Empty-selector warning (non-fatal per RFC — empty selectors are sometimes intentional)
  - Compliance-framework allow-list (channels can only reference declared frameworks)
  - Edge DAG check (rejects cyclic edges)
  - Tight-disruption-budget warning (`maxInFlight=1` on ≥10-host selectors)
  - **New cross-field invariant**: `channel.freshnessWindow ≥ 2 × channel.signingIntervalMinutes`
- **New channel fields**: `signingIntervalMinutes` (default 60), `freshnessWindow` (no default — must declare).
- **New host field**: `pubkey` (nullable ed25519 OpenSSH key — CONTRACTS §II #4).
- **`meta` scaffold** on `fleet.resolved`: `{schemaVersion=1, signedAt=null, ciCommit=null}` — CI fills via new `withSignature` helper.
- **`modules/_trust.nix`** — `nixfleet.trust.{ciReleaseKey,atticCacheKey,orgRootKey}` option tree, each with `.current/.previous/.rejectBefore` for rotation grace + compromise response. Assertions catch `previous` without `current`. Imported into every NixOS host via core module.
- **Homelab example** at `examples/fleet-homelab/` — 3 hosts, 2 channels, all new fields exercised.
- **Eval harness** at `tests/lib/mkFleet/` — positive fixtures with golden JSON, negative fixtures via `tryEval`, `_`-prefix filter for shared helpers.

## Branch status

```
d6cfa25 fix(lib): expose mkFleet via existing nixfleetLib (avoid flake.lib merge conflict)
559b4d1 feat(examples): add homelab example exercising lib/mkFleet end-to-end
dbb29da feat(modules): add nixfleet.trust.* option tree for trust roots
8d80361 feat(lib/mkFleet): add hosts.pubkey and meta scaffold
b29c405 feat(lib/mkFleet): require freshnessWindow ≥ 2×signingIntervalMinutes
b8fb13d feat(lib/mkFleet): warn when disruption budget is impractically tight
8f3871a feat(lib/mkFleet): detect cycles in edges (DAG invariant)
5d9dc78 feat(lib/mkFleet): reject unknown compliance frameworks
2895d48 fix(tests/lib/mkFleet): coerce path to string for replaceStrings
24e8e0e feat(lib/mkFleet): warn on empty selector resolution
f572586 feat(lib/mkFleet): enforce host.configuration is a nixosConfiguration
368e58e test(lib/mkFleet): add fixture-based eval harness
fd90c0c feat(lib): scaffold mkFleet promotion from spike
d31a441 docs(plan): add mkFleet promotion + trust.* implementation plan
```

## Bugs caught during internal review

- **Harness `lib.replaceStrings` with path value** — path must be `toString`-coerced before passing to `replaceStrings`. Silent failure that would have rendered every positive fixture's golden assertion a no-op.
- **`flake.lib` merge conflict** — `lib/flake-module.nix` tried to contribute `flake.lib.mkFleet` separately from `modules/flake-module.nix`'s `flake.lib = nixfleetLib;`. Module system rejects because `flake.lib` has no declared option type. Fix: expose `mkFleet` + `withSignature` via the existing `nixfleetLib` so there's one contribution.

## Pre-push verification (done)

- All 368 workspace tests pass (`cargo nextest run --workspace`)
- Eval tests pass (`modules/tests/eval.nix`)
- `alejandra` formatter clean across all 80 Nix files
- mkFleet harness returns `[ "ok" "ok" "ok" "ok" "ok" "ok" ]` on `nix eval`

## Things to review with extra care

- **`withSignature` CI flow** — the helper is scaffolded but not wired into any CI. Stream A's CI will consume it via `nixfleet-canonicalize` (Stream C).
- **`hasCycle`** — the cycle detector is intentionally verbose (path + visited tracking). Correctness over concision.
- **`signingIntervalMinutes` default of 60** but **`freshnessWindow` has no default** — forces operators to declare replay-defense explicitly per-channel.

## Remaining tasks before ready-to-merge

- Task 13: golden-file acceptance test fixture that imports the homelab example's fleet.nix
- Task 14: CONTRACTS.md §III edit pinning producer-side JCS discipline (**this will make the PR a `contract-change` — requires Stream A + Stream C signoff**)
- Task 15: CHANGELOG + README
- Task 16: wire mkFleet eval harness into `nix flake check`

## Test plan

- [ ] `nix flake check` passes
- [ ] `nix eval --json examples/fleet-homelab#fleet.resolved` produces a valid `schemaVersion: 1` artifact
- [ ] Golden-file harness returns all-ok
- [ ] Trust-options eval test passes
- [ ] 368 Rust tests still green

Closes #1
Partial: #12 (Nix portion — signing tooling lands in Stream C)