### PR TITLE
contract-change: add ECDSA P-256 alongside ed25519 for CI release key

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -26,15 +26,16 @@ Streams referenced:
 | **Schema** | v1 — shape defined in RFC-0001 §4.1 |
 | **Canonicalization** | JCS (RFC 8785), see §IV |
 | **Signature** | CI release key (see §II #1) |
-| **Metadata** | `meta.signedAt` (RFC 3339), `meta.ciCommit`, `meta.schemaVersion` |
+| **Metadata** | `meta.signedAt` (RFC 3339), `meta.ciCommit`, `meta.schemaVersion`, `meta.signatureAlgorithm` (`"ed25519"` \| `"ecdsa-p256"`; optional, defaults to `"ed25519"`) |
 
-**Evolution discipline.** Within v1, fields may be added; consumers MUST ignore unknown fields. Removing or changing the meaning of a field requires `schemaVersion: 2` and a migration window.
+**Evolution discipline.** Within v1, fields may be added; consumers MUST ignore unknown fields. Removing or changing the meaning of a field requires `schemaVersion: 2` and a migration window. `meta.signatureAlgorithm` was added after the initial `schemaVersion: 1` draft — artifacts without the field MUST be interpreted as `"ed25519"` for backward compatibility.
 
 **Consumer MUST verify before use:**
 1. JCS bytes match the canonicalized payload.
-2. Signature verifies against the pinned `nixfleet.trust.ciReleaseKey`.
-3. `(now − meta.signedAt) ≤ channel.freshnessWindow`.
-4. `meta.schemaVersion` is within the consumer's accepted range.
+2. `meta.signatureAlgorithm` (default `"ed25519"`) matches the algorithm of the pinned `nixfleet.trust.ciReleaseKey`.
+3. Signature verifies against the pinned `nixfleet.trust.ciReleaseKey` using the declared algorithm.
+4. `(now − meta.signedAt) ≤ channel.freshnessWindow`.
+5. `meta.schemaVersion` is within the consumer's accepted range.
 
 ### 2. Wire protocol (agent ↔ control plane)
 
@@ -103,12 +104,29 @@ Four keys. Everything else is derived. For each: **who holds the private key, wh
 | **Private** | HSM / TPM-backed keyslot on M70q (Stream A) |
 | **Public (declared)** | `nixfleet.trust.ciReleaseKey` in `fleet.nix` (Stream B) |
 | **Verified by** | CP (on `fleet.resolved` load), optionally agents |
-| **Algorithm** | ed25519 |
+| **Algorithm** | `ed25519` **or** `ecdsa-p256` — declared alongside the public key; the signature's algorithm (§I #1 `meta.signatureAlgorithm`) must match |
 | **Rotation grace** | `nixfleet.trust.ciReleaseKey.previous` valid for 30 days after rotation |
 
+**Algorithm rationale.** ed25519 is the preferred default for HSMs, YubiKeys, cloud KMS, and software-held keys. ECDSA P-256 exists as a second-class citizen because commodity TPM2 hardware (Intel PTT, AMD fTPM, most discrete TPMs) exposes RSA + NIST P-256 but not the ed25519 curve (TPM2_ECC_CURVE_ED25519 = 0x0040 is rare). Both algorithms produce 64-byte signatures and have comparable security margins (~128-bit). Producers (Stream A's CI) pick one at install time based on hardware; the trust-root declaration tells consumers which verifier to use.
+
+**Public-key encoding.**
+- `ed25519` — raw 32-byte public key, base64-encoded in `fleet.nix` (matches the format used by `ssh-keygen`, agenix, minisign).
+- `ecdsa-p256` — uncompressed point, 64 bytes (`X ‖ Y`, no `0x04` prefix), base64-encoded. Consumers convert to SEC1 / DER SPKI at verify time.
+
+The declaration shape:
+
+```nix
+nixfleet.trust.ciReleaseKey = {
+  algorithm = "ecdsa-p256";  # or "ed25519"
+  public    = "<base64 of raw bytes>";
+};
+```
+
+**Signature encoding.** Raw 64 bytes for both algorithms — `R ‖ S` for ECDSA, standard `R ‖ S` for ed25519. No DER wrapping, no PGP armour. Put next to the canonical payload as `fleet.resolved.json.sig`.
+
 **Rotation procedure.**
-1. Generate new keypair in HSM (Stream A).
-2. Commit: set `ciReleaseKey = <new>`, `ciReleaseKey.previous = <old>` in `fleet.nix`.
+1. Generate new keypair (Stream A) — may differ in algorithm from the outgoing one.
+2. Commit: set `ciReleaseKey = <new>`, `ciReleaseKey.previous = <old>` in `fleet.nix`. Consumers that pin both must accept signatures under either algorithm during the overlap.
 3. CI starts signing with new key on next build.
 4. After 30 days, remove `previous` from `fleet.nix`; old-key-signed artifacts rejected.
 
@@ -196,7 +214,7 @@ The control plane's SQLite database exists to cache operational state. Every col
 
 | Contract | Current version | Evolution |
 |---|---|---|
-| `fleet.resolved.json` | `schemaVersion: 1` | Additive within v1; bump for breaking changes |
+| `fleet.resolved.json` | `schemaVersion: 1` | Additive within v1; bump for breaking changes. `meta.signatureAlgorithm` added in v1 — optional, defaults to `"ed25519"` when absent. |
 | Wire protocol | v1 (header) | Additive within major; dual-support during migration |
 | Probe descriptor per framework | `<framework>/v1` per framework | New string for new shape; old shape kept during migration |
 | Probe output | Tracked with the control | Same as descriptor |


### PR DESCRIPTION
## Problem

CONTRACTS.md §II #1 hard-requires **ed25519** for the CI release key. Commodity TPM2 hardware (Intel PTT on the v0.2 reference M70q, AMD fTPM, most discrete TPMs) does not expose TPM ECC curve 0x0040 — so ed25519 isn't available for hardware-backed signing on the same boxes we want to protect with the trust model. TPM-accepted signing primitives are limited to RSA and ECDSA P-256.

Forcing ed25519 would push operators to either software-held keys (which defeats §II's whole point) or specialty HSMs / YubiKeys. ECDSA P-256 is the pragmatic path.

## Change

**§I #1 `fleet.resolved.json`**
- New optional metadata field `meta.signatureAlgorithm: "ed25519" | "ecdsa-p256"`.
- Backward-compatible default — absent ⇒ `"ed25519"`.
- Consumer MUST-verify rules add an explicit "algorithm matches pinned key" step before signature check.

**§II #1 CI release key**
- Algorithm: `ed25519` **or** `ecdsa-p256`.
- Declaration becomes a typed submodule (`algorithm` + `public`) so consumers learn the algorithm without out-of-band knowledge.
- Raw-bytes encoding pinned per algorithm:
  - ed25519 → 32-byte raw pubkey
  - ecdsa-p256 → 64-byte uncompressed point (`X ‖ Y`, no `0x04` prefix)
- Signature format: 64 raw bytes for both (`R ‖ S`). No DER wrapping.
- Rotation procedure updated so algorithm swaps use the standard `previous` overlap window.

**§V Versioning**
- Note: `meta.signatureAlgorithm` is an additive v1 field.

## Rationale

| | ed25519 | ECDSA P-256 |
|---|---|---|
| TPM hardware support | Rare (TPM ECC 0x0040) | Universal on commodity TPMs |
| Signature size | 64 B | 64 B (raw) |
| Verification speed | Fastest | Fast |
| Rust crate | ed25519-dalek / ring | p256 / ring |
| Rest of the world | Cryptography research sweetheart | NIST-recommended, FIPS 140-3 |

Why not RSA? Four times the signature size, slower verification, and the signature suite bloats (PKCS#1 v1.5 vs PSS, hash choice). Not worth the extra contract surface.

Why not single-algo ECDSA P-256 (drop ed25519)? HSM / YubiKey / cloud KMS users get native ed25519 support; forcing them off the modern primitive for parity with the TPM case loses on all fronts.

## Downstream impact

| Stream | Work |
|---|---|
| **A — infra** | Scope `nixfleet.tpmKeyslot.algorithm` default swapped to `ecdsa-p256` on hardware-realistic setups. Scope + fleet updates paired: [abstracts33d/nixfleet-scopes#2](https://github.com/abstracts33d/nixfleet-scopes/pull/2) (commit `074cd9e`) + [abstracts33d/fleet#23](https://github.com/abstracts33d/fleet/pull/23). |
| **B — nix schema** | `nixfleet.trust.ciReleaseKey` becomes a submodule (`algorithm` + `public`). Trivial option-type change in the `modules/trust.nix` PR-in-flight. |
| **C — rust proto + verifier** | `nixfleet-proto` serde type for `fleet.resolved` gains an optional `meta.signatureAlgorithm` field. Verifier in `nixfleet-reconciler` branches on it via `ed25519-dalek` + `p256::ecdsa`. ~100 lines total; worth landing now rather than retrofitting after `feat/3-reconciler-proto` lands. |

## Amendment procedure compliance (§VII)

- [x] Labelled `contract-change`.
- [ ] Review + signoff from **Stream A** (code landing on `abstracts33d/nixfleet-scopes#2` + `abstracts33d/fleet#23`).
- [ ] Review + signoff from **Stream C** (code landing on `feat/3-reconciler-proto` — ping pending).
- [ ] Stream B signoff (schema change is small; can be bundled in their in-flight `mkFleet` PR or a follow-up).

This PR is docs-only. Paired implementation PRs:
- Scope change: https://github.com/abstracts33d/nixfleet-scopes/pull/2 (commit `074cd9e`, `feat(tpm-keyslot): add ECDSA P-256 algorithm`)
- Fleet consumer: https://github.com/abstracts33d/fleet/pull/23 (already picks up the scope change via lock bump; can set `nixfleet.tpmKeyslot.algorithm = "ecdsa-p256"` explicitly once merged).

Tracked on the v0.2 board: [abstracts33d/nixfleet#10](https://github.com/abstracts33d/nixfleet/issues/10).