### PR TITLE
feat(reconciler): TrustedPubkey + algorithm-dispatching verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,6 +1703,7 @@ name = "nixfleet-reconciler"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "base64",
  "chrono",
  "ed25519-dalek",
  "nixfleet-canonicalize",

--- a/crates/nixfleet-proto/src/lib.rs
+++ b/crates/nixfleet-proto/src/lib.rs
@@ -24,8 +24,10 @@
 //! not the serde level.
 
 pub mod fleet_resolved;
+pub mod trust;
 
 pub use fleet_resolved::{
     Channel, Compliance, ComplianceProbes, DisruptionBudget, Edge, FleetResolved, HealthGate, Host,
     Meta, PolicyWave, RolloutPolicy, Selector, SystemdFailedUnits, Wave,
 };
+pub use trust::TrustedPubkey;

--- a/crates/nixfleet-proto/src/trust.rs
+++ b/crates/nixfleet-proto/src/trust.rs
@@ -1,0 +1,49 @@
+//! Trust root declarations (CONTRACTS.md §II).
+//!
+//! A [`TrustedPubkey`] pairs a signature algorithm with its public key
+//! material. Per CONTRACTS.md §II, the algorithm is a property of the
+//! key (not of the signed artifact) — a given private key produces
+//! signatures in exactly one algorithm. The verifier matches
+//! `(artifact, signature) → declared trust root → algorithm → verify
+//! routine`; the artifact MUST NOT carry its own algorithm claim.
+//!
+//! # Rotation
+//!
+//! Callers pass a list of trust roots (`&[TrustedPubkey]`). The
+//! verifier tries each in declaration order; first match wins. This
+//! supports the `ciReleaseKey.previous` rotation grace window
+//! described in CONTRACTS.md §II #1 — and, when a future PR amends
+//! §II to allow non-ed25519 algorithms, it supports cross-algorithm
+//! rotation (old `ed25519` plus new `p256` both valid for N days).
+//!
+//! # Algorithm extensibility
+//!
+//! The type is a flat struct with a `String` algorithm tag rather than
+//! a Rust `enum`. Rationale: this crate mirrors the wire contract;
+//! forward compatibility means the proto parses an unknown algorithm
+//! without error (it's the verifier's job to reject), and an old
+//! proto parsing a newer Nix-declared `{ "algorithm": "p256", ... }`
+//! must not crash. Unknown algorithms surface as
+//! `VerifyError::UnsupportedAlgorithm` at verify time, where they can
+//! be logged with the algorithm name for operator visibility.
+
+use serde::{Deserialize, Serialize};
+
+/// A trust root: algorithm + public key material.
+///
+/// Currently supported algorithms:
+/// - `ed25519`: `public` is the 32-byte Edwards-curve public key, base64
+///   (standard alphabet, with padding) encoded.
+///
+/// Future algorithms (e.g. `p256`) extend this schema without a major
+/// version bump; consumers ignore trust roots whose `algorithm` they
+/// do not recognize (emitting an event) rather than refusing to start.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrustedPubkey {
+    /// Short algorithm name as declared in `fleet.nix`'s trust tree.
+    pub algorithm: String,
+    /// Base64-encoded public key bytes. Decoding is algorithm-specific
+    /// and happens inside the verifier.
+    pub public: String,
+}

--- a/crates/nixfleet-reconciler/Cargo.toml
+++ b/crates/nixfleet-reconciler/Cargo.toml
@@ -21,6 +21,7 @@ chrono = { version = "0.4", features = ["serde"] }
 ed25519-dalek = "2"
 anyhow = "1"
 thiserror = "2"
+base64 = "0.22"
 
 [dev-dependencies]
 rand = "0.9"

--- a/crates/nixfleet-reconciler/src/verify.rs
+++ b/crates/nixfleet-reconciler/src/verify.rs
@@ -1,8 +1,10 @@
 //! RFC-0002 §4 step 0 — fetch + verify + freshness-gate.
 
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use ed25519_dalek::{Signature, VerifyingKey};
-use nixfleet_proto::FleetResolved;
+use nixfleet_proto::{FleetResolved, TrustedPubkey};
 use std::time::Duration;
 use thiserror::Error;
 
@@ -14,7 +16,7 @@ pub enum VerifyError {
     #[error("fleet.resolved parse failed: {0}")]
     Parse(#[from] serde_json::Error),
 
-    #[error("signature does not verify against the pinned CI release key")]
+    #[error("signature does not verify against any declared trust root")]
     BadSignature,
 
     #[error("artifact is unsigned (meta.signedAt is null)")]
@@ -32,16 +34,52 @@ pub enum VerifyError {
 
     #[error("JCS re-canonicalization failed: {0}")]
     Canonicalize(#[source] anyhow::Error),
+
+    #[error("unsupported signature algorithm: {algorithm} (supported: ed25519)")]
+    UnsupportedAlgorithm { algorithm: String },
+
+    #[error("trusted pubkey material is malformed ({algorithm}): {reason}")]
+    BadPubkeyEncoding { algorithm: String, reason: String },
+
+    #[error("no trust roots configured for artifact verification")]
+    NoTrustRoots,
 }
 
 /// Verify a signed `fleet.resolved` artifact per RFC-0002 §4 step 0.
+///
+/// # Trust root list
+///
+/// `trusted_keys` is a list to support [`CONTRACTS.md §II`]'s rotation
+/// grace window — during a key rotation, the previous and current keys
+/// are BOTH valid trust roots for up to 30 days. The verifier tries
+/// each in declaration order; the first key whose algorithm is
+/// supported AND whose `verify_strict` accepts the signature wins.
+///
+/// Entries with unsupported algorithms are skipped (with no error),
+/// enabling forward compatibility: when `#18` amends §II to add e.g.
+/// `p256`, an older verifier binary can still operate against a
+/// mixed-algorithm `trust.ciReleaseKeys` list; it just only matches
+/// the subset of keys whose algorithms it knows.
+///
+/// # Signature width
+///
+/// `signature` is a byte slice, not a fixed-size array. Per-algorithm
+/// length validation happens inside the dispatcher. ed25519 expects
+/// exactly 64 bytes (32-byte R || 32-byte s). A future `p256` branch
+/// will decide whether to accept raw r||s (64 bytes) or DER-encoded
+/// (variable) — for now, non-ed25519 algorithms bail with
+/// `UnsupportedAlgorithm`.
 pub fn verify_artifact(
     signed_bytes: &[u8],
-    signature: &[u8; 64],
-    pubkey: &VerifyingKey,
+    signature: &[u8],
+    trusted_keys: &[TrustedPubkey],
     now: DateTime<Utc>,
     freshness_window: Duration,
 ) -> Result<FleetResolved, VerifyError> {
+    if trusted_keys.is_empty() {
+        return Err(VerifyError::NoTrustRoots);
+    }
+
     // Step 1: parse as generic JSON so we can re-canonicalize it.
     let raw_str = std::str::from_utf8(signed_bytes).map_err(|e| {
         VerifyError::Parse(serde_json::Error::io(std::io::Error::new(
@@ -55,18 +93,82 @@ pub fn verify_artifact(
     let canonical =
         nixfleet_canonicalize::canonicalize(raw_str).map_err(VerifyError::Canonicalize)?;
 
-    // Step 3: ed25519 signature verification against canonical bytes.
-    //
-    // `verify_strict` rejects malleable signatures (non-canonical R component
-    // or s >= L) — required for the pinned CI release key per CONTRACTS.md
-    // §II #1 and the spec for this crate. Do not downgrade to `verify`.
-    let sig = Signature::from_bytes(signature);
-    pubkey
-        .verify_strict(canonical.as_bytes(), &sig)
-        .map_err(|_| VerifyError::BadSignature)?;
+    // Step 3: try each trust root. First matching signature wins.
+    let mut attempted_any_supported = false;
+    for key in trusted_keys {
+        match key.algorithm.as_str() {
+            "ed25519" => {
+                attempted_any_supported = true;
+                if verify_ed25519(canonical.as_bytes(), signature, &key.public).is_ok() {
+                    // Signature verified; proceed to the remaining gates.
+                    return finish_verification(&canonical, now, freshness_window);
+                }
+            }
+            _other => {
+                // Unknown algorithm — skip this trust root (forward compat).
+                // Only report UnsupportedAlgorithm if NO supported algorithm
+                // appears in the list (below).
+                continue;
+            }
+        }
+    }
 
-    // Step 4: now safe to type-parse.
-    let fleet: FleetResolved = serde_json::from_str(&canonical)?;
+    if !attempted_any_supported {
+        // The operator declared only unknown algorithms. Surface the first
+        // unknown one so logs are actionable.
+        return Err(VerifyError::UnsupportedAlgorithm {
+            algorithm: trusted_keys[0].algorithm.clone(),
+        });
+    }
+    Err(VerifyError::BadSignature)
+}
+
+/// Dispatched verification for ed25519. `verify_strict` rejects malleable
+/// signatures (non-canonical R or `s >= L`) — required for root-of-trust
+/// keys per CONTRACTS.md §II #1.
+fn verify_ed25519(
+    canonical_bytes: &[u8],
+    signature: &[u8],
+    public_b64: &str,
+) -> Result<(), VerifyError> {
+    let public_bytes =
+        BASE64_STANDARD
+            .decode(public_b64)
+            .map_err(|e| VerifyError::BadPubkeyEncoding {
+                algorithm: "ed25519".into(),
+                reason: format!("base64 decode failed: {e}"),
+            })?;
+    let public_array: [u8; 32] =
+        public_bytes
+            .try_into()
+            .map_err(|v: Vec<u8>| VerifyError::BadPubkeyEncoding {
+                algorithm: "ed25519".into(),
+                reason: format!("expected 32 bytes, got {}", v.len()),
+            })?;
+    let verifying_key =
+        VerifyingKey::from_bytes(&public_array).map_err(|e| VerifyError::BadPubkeyEncoding {
+            algorithm: "ed25519".into(),
+            reason: e.to_string(),
+        })?;
+
+    let sig_array: [u8; 64] = signature
+        .try_into()
+        .map_err(|_| VerifyError::BadSignature)?;
+    let sig = Signature::from_bytes(&sig_array);
+
+    verifying_key
+        .verify_strict(canonical_bytes, &sig)
+        .map_err(|_| VerifyError::BadSignature)
+}
+
+/// Steps 4-6 after signature verification: type-parse, schema-gate, freshness.
+fn finish_verification(
+    canonical: &str,
+    now: DateTime<Utc>,
+    freshness_window: Duration,
+) -> Result<FleetResolved, VerifyError> {
+    // Step 4: type-parse.
+    let fleet: FleetResolved = serde_json::from_str(canonical)?;
 
     // Step 5: schemaVersion gate.
     if fleet.schema_version != ACCEPTED_SCHEMA_VERSION {
@@ -74,11 +176,6 @@ pub fn verify_artifact(
     }
 
     // Step 6: freshness.
-    //
-    // Unsigned artifacts (`meta.signedAt: null`) are a distinct failure
-    // mode from signed-but-stale and surface as `NotSigned`. Stream B's
-    // unsigned test fixtures exercise this path; production fleet.resolved
-    // from CI always carries a `signedAt` timestamp.
     let signed_at = fleet.meta.signed_at.ok_or(VerifyError::NotSigned)?;
     let window = ChronoDuration::from_std(freshness_window)
         .expect("freshness_window fits in i64 nanoseconds — multi-century windows are a bug");

--- a/crates/nixfleet-reconciler/tests/verify.rs
+++ b/crates/nixfleet-reconciler/tests/verify.rs
@@ -1,8 +1,11 @@
 //! Step 0 — signature verification + freshness window.
 
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use ed25519_dalek::{Signer, SigningKey};
 use nixfleet_canonicalize::canonicalize;
+use nixfleet_proto::TrustedPubkey;
 use nixfleet_reconciler::{verify_artifact, VerifyError};
 use rand::rngs::OsRng;
 use rand::TryRngCore;
@@ -20,19 +23,19 @@ fn fresh_signing_key() -> SigningKey {
     SigningKey::from_bytes(&seed)
 }
 
+fn trust_root_for(signing_key: &SigningKey) -> TrustedPubkey {
+    TrustedPubkey {
+        algorithm: "ed25519".to_string(),
+        public: BASE64_STANDARD.encode(signing_key.verifying_key().as_bytes()),
+    }
+}
+
 /// Build a signed fleet.resolved artifact from JSON source.
 ///
-/// Returns (signed_bytes, signature, pubkey, signed_at).
-fn sign_artifact(
-    json: &str,
-) -> (
-    Vec<u8>,
-    [u8; 64],
-    ed25519_dalek::VerifyingKey,
-    DateTime<Utc>,
-) {
+/// Returns (signed_bytes, signature, trust_root, signed_at).
+fn sign_artifact(json: &str) -> (Vec<u8>, [u8; 64], TrustedPubkey, DateTime<Utc>) {
     let signing_key = fresh_signing_key();
-    let pubkey = signing_key.verifying_key();
+    let trust = trust_root_for(&signing_key);
 
     let value: serde_json::Value = serde_json::from_str(json).expect("parse");
     let signed_at: DateTime<Utc> = value["meta"]["signedAt"]
@@ -45,7 +48,7 @@ fn sign_artifact(
     let canonical = canonicalize(&reserialized).expect("canonicalize");
     let sig = signing_key.sign(canonical.as_bytes()).to_bytes();
 
-    (canonical.into_bytes(), sig, pubkey, signed_at)
+    (canonical.into_bytes(), sig, trust, signed_at)
 }
 
 const FIXTURE_SIGNED: &str =
@@ -53,11 +56,11 @@ const FIXTURE_SIGNED: &str =
 
 #[test]
 fn verify_ok_returns_fleet() {
-    let (bytes, sig, pubkey, signed_at) = sign_artifact(FIXTURE_SIGNED);
+    let (bytes, sig, trust, signed_at) = sign_artifact(FIXTURE_SIGNED);
     let now = signed_at + ChronoDuration::minutes(30);
     let window = Duration::from_secs(3 * 3600);
 
-    let result = verify_artifact(&bytes, &sig, &pubkey, now, window);
+    let result = verify_artifact(&bytes, &sig, std::slice::from_ref(&trust), now, window);
 
     let fleet = result.expect("verify_ok");
     assert_eq!(fleet.schema_version, 1);
@@ -66,33 +69,33 @@ fn verify_ok_returns_fleet() {
 
 #[test]
 fn verify_bad_signature() {
-    let (bytes, mut sig, pubkey, signed_at) = sign_artifact(FIXTURE_SIGNED);
+    let (bytes, mut sig, trust, signed_at) = sign_artifact(FIXTURE_SIGNED);
     sig[0] ^= 0xFF;
     let now = signed_at + ChronoDuration::minutes(30);
     let window = Duration::from_secs(3 * 3600);
 
-    let err = verify_artifact(&bytes, &sig, &pubkey, now, window).unwrap_err();
+    let err = verify_artifact(&bytes, &sig, std::slice::from_ref(&trust), now, window).unwrap_err();
     assert!(matches!(err, VerifyError::BadSignature));
 }
 
 #[test]
 fn verify_stale() {
-    let (bytes, sig, pubkey, signed_at) = sign_artifact(FIXTURE_SIGNED);
+    let (bytes, sig, trust, signed_at) = sign_artifact(FIXTURE_SIGNED);
     let now = signed_at + ChronoDuration::hours(4);
     let window = Duration::from_secs(3 * 3600);
 
-    let err = verify_artifact(&bytes, &sig, &pubkey, now, window).unwrap_err();
+    let err = verify_artifact(&bytes, &sig, std::slice::from_ref(&trust), now, window).unwrap_err();
     assert!(matches!(err, VerifyError::Stale { .. }));
 }
 
 #[test]
 fn verify_at_exact_window_boundary_is_fresh() {
-    let (bytes, sig, pubkey, signed_at) = sign_artifact(FIXTURE_SIGNED);
+    let (bytes, sig, trust, signed_at) = sign_artifact(FIXTURE_SIGNED);
     let window_secs: u64 = 3 * 3600;
     let now = signed_at + ChronoDuration::seconds(window_secs as i64);
     let window = Duration::from_secs(window_secs);
 
-    let result = verify_artifact(&bytes, &sig, &pubkey, now, window);
+    let result = verify_artifact(&bytes, &sig, std::slice::from_ref(&trust), now, window);
     assert!(
         result.is_ok(),
         "age == window must be treated as fresh: {result:?}"
@@ -104,14 +107,21 @@ fn verify_unsigned() {
     let json = include_str!("../../nixfleet-proto/tests/fixtures/every-nullable.json");
 
     let signing_key = fresh_signing_key();
-    let pubkey = signing_key.verifying_key();
+    let trust = trust_root_for(&signing_key);
     let canonical = canonicalize(json).expect("canonicalize");
     let sig = signing_key.sign(canonical.as_bytes()).to_bytes();
 
     let now = Utc::now();
     let window = Duration::from_secs(3 * 3600);
 
-    let err = verify_artifact(canonical.as_bytes(), &sig, &pubkey, now, window).unwrap_err();
+    let err = verify_artifact(
+        canonical.as_bytes(),
+        &sig,
+        std::slice::from_ref(&trust),
+        now,
+        window,
+    )
+    .unwrap_err();
     assert!(matches!(err, VerifyError::NotSigned));
 }
 
@@ -121,7 +131,7 @@ fn verify_rejects_malleable_signature() {
     // verify_strict rejects any s >= L. We construct a malleable sig by
     // adding L to the scalar component — ed25519-dalek 2's verify_strict
     // catches this; the weaker verify would accept it.
-    let (bytes, sig, pubkey, signed_at) = sign_artifact(FIXTURE_SIGNED);
+    let (bytes, sig, trust, signed_at) = sign_artifact(FIXTURE_SIGNED);
 
     // L (little-endian 32 bytes) = 2^252 + 27742317777372353535851937790883648493
     const L_LE: [u8; 32] = [
@@ -130,9 +140,6 @@ fn verify_rejects_malleable_signature() {
         0x00, 0x10,
     ];
 
-    // Add L to s (the low 32 bytes of the 64-byte sig). If s + L overflows
-    // the 32-byte field, fall back to the plain bit-flip malleability test
-    // (non-canonical R encoding also triggers strict rejection).
     let mut malleable = sig;
     let mut carry: u16 = 0;
     for i in 0..32 {
@@ -144,7 +151,13 @@ fn verify_rejects_malleable_signature() {
     let now = signed_at + ChronoDuration::minutes(30);
     let window = Duration::from_secs(3 * 3600);
 
-    let result = verify_artifact(&bytes, &malleable, &pubkey, now, window);
+    let result = verify_artifact(
+        &bytes,
+        &malleable,
+        std::slice::from_ref(&trust),
+        now,
+        window,
+    );
     assert!(
         matches!(result, Err(VerifyError::BadSignature)),
         "verify_strict must reject malleable s >= L: got {result:?}"
@@ -158,7 +171,7 @@ fn verify_unsupported_schema() {
     let json = value.to_string();
 
     let signing_key = fresh_signing_key();
-    let pubkey = signing_key.verifying_key();
+    let trust = trust_root_for(&signing_key);
     let canonical = canonicalize(&json).expect("canonicalize");
     let sig = signing_key.sign(canonical.as_bytes()).to_bytes();
 
@@ -166,25 +179,38 @@ fn verify_unsupported_schema() {
     let now = signed_at + ChronoDuration::minutes(30);
     let window = Duration::from_secs(3 * 3600);
 
-    let err = verify_artifact(canonical.as_bytes(), &sig, &pubkey, now, window).unwrap_err();
+    let err = verify_artifact(
+        canonical.as_bytes(),
+        &sig,
+        std::slice::from_ref(&trust),
+        now,
+        window,
+    )
+    .unwrap_err();
     assert!(matches!(err, VerifyError::SchemaVersionUnsupported(2)));
 }
 
 #[test]
 fn verify_malformed_json() {
     let signing_key = fresh_signing_key();
-    let pubkey = signing_key.verifying_key();
+    let trust = trust_root_for(&signing_key);
     let bytes = b"{not json";
     let sig = [0u8; 64];
 
-    let err =
-        verify_artifact(bytes, &sig, &pubkey, Utc::now(), Duration::from_secs(60)).unwrap_err();
+    let err = verify_artifact(
+        bytes,
+        &sig,
+        std::slice::from_ref(&trust),
+        Utc::now(),
+        Duration::from_secs(60),
+    )
+    .unwrap_err();
     assert!(matches!(err, VerifyError::Parse(_)));
 }
 
 #[test]
 fn verify_tampered_payload() {
-    let (bytes, sig, pubkey, signed_at) = sign_artifact(FIXTURE_SIGNED);
+    let (bytes, sig, trust, signed_at) = sign_artifact(FIXTURE_SIGNED);
     let mut tampered = bytes.clone();
     if let Some(byte) = tampered.iter_mut().find(|b| **b == b'"') {
         *byte = b'_';
@@ -192,9 +218,113 @@ fn verify_tampered_payload() {
     let now = signed_at + ChronoDuration::minutes(30);
     let window = Duration::from_secs(3 * 3600);
 
-    let err = verify_artifact(&tampered, &sig, &pubkey, now, window).unwrap_err();
+    let err =
+        verify_artifact(&tampered, &sig, std::slice::from_ref(&trust), now, window).unwrap_err();
     assert!(
         matches!(err, VerifyError::Parse(_) | VerifyError::BadSignature),
         "got {err:?}"
     );
+}
+
+// ---- New tests exercising the trust-root architecture -----------------
+
+#[test]
+fn verify_with_empty_trust_roots_errors() {
+    let (bytes, sig, _trust, signed_at) = sign_artifact(FIXTURE_SIGNED);
+    let now = signed_at + ChronoDuration::minutes(30);
+    let window = Duration::from_secs(3 * 3600);
+
+    let err = verify_artifact(&bytes, &sig, &[], now, window).unwrap_err();
+    assert!(matches!(err, VerifyError::NoTrustRoots));
+}
+
+#[test]
+fn verify_rotation_with_two_keys_tries_each_in_order() {
+    // Simulate a rotation grace window: old key is declared first, new
+    // key is declared second. The signature was produced by the new key.
+    // Verifier tries the old key (fails) then the new key (succeeds).
+    let old_key = fresh_signing_key();
+    let new_key = fresh_signing_key();
+    let trust_roots = vec![trust_root_for(&old_key), trust_root_for(&new_key)];
+
+    let value: serde_json::Value = serde_json::from_str(FIXTURE_SIGNED).unwrap();
+    let signed_at: DateTime<Utc> = value["meta"]["signedAt"].as_str().unwrap().parse().unwrap();
+    let canonical = canonicalize(&value.to_string()).unwrap();
+    let sig = new_key.sign(canonical.as_bytes()).to_bytes();
+
+    let now = signed_at + ChronoDuration::minutes(30);
+    let window = Duration::from_secs(3 * 3600);
+
+    let result = verify_artifact(canonical.as_bytes(), &sig, &trust_roots, now, window);
+    assert!(
+        result.is_ok(),
+        "rotation-order list must accept the second key: {result:?}"
+    );
+}
+
+#[test]
+fn verify_rejects_when_only_unknown_algorithm_declared() {
+    // Operator declares a trust root with a future algorithm this binary
+    // doesn't know about. Verifier rejects with UnsupportedAlgorithm —
+    // NOT BadSignature — so ops logs are actionable.
+    let (bytes, sig, _trust, signed_at) = sign_artifact(FIXTURE_SIGNED);
+    let future_only = vec![TrustedPubkey {
+        algorithm: "p256".to_string(),
+        public: "somebase64value==".to_string(),
+    }];
+    let now = signed_at + ChronoDuration::minutes(30);
+    let window = Duration::from_secs(3 * 3600);
+
+    let err = verify_artifact(&bytes, &sig, &future_only, now, window).unwrap_err();
+    match err {
+        VerifyError::UnsupportedAlgorithm { algorithm } => {
+            assert_eq!(algorithm, "p256");
+        }
+        other => panic!("expected UnsupportedAlgorithm, got {other:?}"),
+    }
+}
+
+#[test]
+fn verify_skips_unknown_algorithm_when_known_also_present() {
+    // Mixed declaration: an unknown-to-this-binary algorithm is listed
+    // alongside the ed25519 key that actually signed. Verifier skips the
+    // unknown entry, matches the known one, returns Ok. This is the
+    // forward-compat path for a rolling upgrade where some operators
+    // have a newer Nix declaration but an older verifier binary.
+    let (bytes, sig, ed_trust, signed_at) = sign_artifact(FIXTURE_SIGNED);
+    let mixed = vec![
+        TrustedPubkey {
+            algorithm: "p256".to_string(),
+            public: "somebase64value==".to_string(),
+        },
+        ed_trust,
+    ];
+    let now = signed_at + ChronoDuration::minutes(30);
+    let window = Duration::from_secs(3 * 3600);
+
+    let result = verify_artifact(&bytes, &sig, &mixed, now, window);
+    assert!(
+        result.is_ok(),
+        "mixed-algorithm list with one known key must verify: {result:?}"
+    );
+}
+
+#[test]
+fn verify_rejects_malformed_pubkey_encoding() {
+    let (bytes, sig, _trust, signed_at) = sign_artifact(FIXTURE_SIGNED);
+    let bad_key = vec![TrustedPubkey {
+        algorithm: "ed25519".to_string(),
+        public: "!!! not base64 !!!".to_string(),
+    }];
+    let now = signed_at + ChronoDuration::minutes(30);
+    let window = Duration::from_secs(3 * 3600);
+
+    // Malformed key doesn't verify → fall through to BadSignature. Operators
+    // see "no key verified" rather than a per-key decode error. If the
+    // opposite behavior is desired (surface decode errors loudly), a future
+    // PR can change verify_ed25519 to propagate BadPubkeyEncoding; this test
+    // pins the current "skip on decode failure" behavior so the change is
+    // deliberate.
+    let err = verify_artifact(&bytes, &sig, &bad_key, now, window).unwrap_err();
+    assert!(matches!(err, VerifyError::BadSignature));
 }


### PR DESCRIPTION
Stacked on #19 (`feat/3-reconciler-proto`). Further stacked on #16 (`feat/12-canonicalize-jcs-pin`).

Implements the architectural shape needed for the upcoming signature-algorithm contract change (#18) without actually adding new algorithms yet. Landing this first means #18's implementing PR becomes a pure addition (new algorithm branch + its malleability test); the surface area is already right-shaped.

## Summary
- **`nixfleet_proto::TrustedPubkey`** — flat struct `{ algorithm: String, public: String }` mirroring a trust root declaration from §II. Algorithm is paired with the key material at declaration time, not carried on the artifact.
- **`verify_artifact` signature widened**:
  - `signature: &[u8; 64]` → `&[u8]` (p256 DER won't fit 64 bytes).
  - `pubkey: &VerifyingKey` → `trusted_keys: &[TrustedPubkey]` (list supports rotation grace per §II #1; cross-algorithm rotation becomes natural when #18 adds p256).
- **Forward-compat on unknown algorithms**: trust roots with unknown `algorithm` strings are skipped, not errored — so a newer Nix-declared list containing `p256` + `ed25519` entries verifies cleanly against an older binary that only knows `ed25519`. If ALL declared algorithms are unknown, `VerifyError::UnsupportedAlgorithm { algorithm }` surfaces the first one by name so operator logs are actionable.
- **New `VerifyError` variants**: `UnsupportedAlgorithm { algorithm }`, `BadPubkeyEncoding { algorithm, reason }`, `NoTrustRoots`.

## Why this landed separately from #19

Reviewer (see PR #19 body + inline discussion) raised three concerns about #18's shape:

1. Sequencing per `docs/CONTRACTS.md §VII` — the contract amendment PR (#18) is a Draft until the implementing code is ready; this PR is the first half of that implementation (architecture ready; algorithm additions pending).
2. Proto shape — algorithm belongs on the trust root declaration, not `meta.signatureAlgorithm` on the artifact. Addressed via `TrustedPubkey`.
3. Verifier shape — signature type must widen, algorithm dispatch must be pluggable, forward compat required. Addressed.

`p256` implementation + its low-s/malleability-rejection test + its `verify_rejects_malleable_p256_signature` test land in a follow-up stacked on top of this one, once #18 is ready to un-draft.

## Test plan
- [x] All 9 pre-existing verify tests still pass unchanged (call sites updated for the new signature).
- [x] 5 new tests lock in the new surface:
  - `verify_with_empty_trust_roots_errors` → `NoTrustRoots`.
  - `verify_rotation_with_two_keys_tries_each_in_order` — two-key list, sig from the second key, verifies.
  - `verify_rejects_when_only_unknown_algorithm_declared` → `UnsupportedAlgorithm { algorithm: \"p256\" }`.
  - `verify_skips_unknown_algorithm_when_known_also_present` — mixed list verifies via the known key.
  - `verify_rejects_malformed_pubkey_encoding` — pins current \"fail-closed on bad key, fall to BadSignature\" behavior.
- [x] `cargo test -p nixfleet-proto` → 4 passed (unchanged).
- [x] `cargo test -p nixfleet-reconciler` → 36 passed (6 unit + 4 budgets_edges + 5 host + 7 rollout + 14 verify). Previously 31.

## Scope
- No CONTRACTS.md amendment here — this PR implements the architectural shape the future #18 amendment will rely on.
- No p256 support yet; follow-up PR adds that.
- No changes to `reconcile`, `Action`, `Observed`, or anywhere else outside verify-path + proto.

## Stacking
- Base: `feat/3-reconciler-proto` (PR #19).
- Rebased onto `main` when #19 merges.
- `feat/12-canonicalize-jcs-pin` (PR #16) must merge first, then #19, then this.

## Hook note
Pre-push hook skipped on initial push at user request (same as #19). Reviewer: please run the full gauntlet locally before merge.