### PR TITLE
feat(lib/mkFleet): optional signatureAlgorithm in withSignature + symmetric trust-options fixture

### DIFF
--- a/lib/mkFleet.nix
+++ b/lib/mkFleet.nix
@@ -408,13 +408,23 @@
     in
       builtins.seq emittedWarnings resolved;
 
+  # Stamp CI-provided signing metadata onto a resolved fleet value.
+  # `signatureAlgorithm` is optional — omit it when signing with ed25519
+  # (the default per CONTRACTS §I #1 for backward-compatible consumers).
+  # Set it to `"ecdsa-p256"` (or any future value the contract accepts)
+  # when Stream A's CI signs with a non-default algorithm, e.g. when the
+  # TPM keyslot emits ECDSA P-256.
   withSignature = {
     signedAt,
     ciCommit,
+    signatureAlgorithm ? null,
   }: resolved:
     resolved
     // {
-      meta = resolved.meta // {inherit signedAt ciCommit;};
+      meta =
+        resolved.meta
+        // {inherit signedAt ciCommit;}
+        // lib.optionalAttrs (signatureAlgorithm != null) {inherit signatureAlgorithm;};
     };
 in {
   inherit withSignature;

--- a/modules/tests/_trust-options.nix
+++ b/modules/tests/_trust-options.nix
@@ -12,22 +12,21 @@
   pkgs,
   ...
 }: let
-  happy =
+  assertionsShim = {
+    options.assertions = lib.mkOption {
+      type = lib.types.listOf lib.types.unspecified;
+      default = [];
+    };
+  };
+
+  evalTrustWith = ciReleaseKey:
     (lib.evalModules {
       modules = [
         ../_trust.nix
-        {
-          options.assertions = lib.mkOption {
-            type = lib.types.listOf lib.types.unspecified;
-            default = [];
-          };
-        }
+        assertionsShim
         {
           nixfleet.trust = {
-            ciReleaseKey.current = {
-              algorithm = "ecdsa-p256";
-              public = "AAAAcdsap256placeholderbase64bytesXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
-            };
+            inherit ciReleaseKey;
             atticCacheKey.current = "attic:cache.example.com:AAAA...";
           };
         }
@@ -35,10 +34,29 @@
       specialArgs = {inherit pkgs;};
     })
     .config;
+
+  p256Key = {
+    algorithm = "ecdsa-p256";
+    public = "AAAAcdsap256placeholderbase64bytesXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+  };
+  ed25519Key = {
+    algorithm = "ed25519";
+    public = "AAAAed25519placeholderbase64bytesXXXXXXXXXXXXXX";
+  };
+
+  happyP256 = evalTrustWith {current = p256Key;};
+  happyEd25519 = evalTrustWith {current = ed25519Key;};
 in {
-  happyCiKeyAlgorithm = happy.nixfleet.trust.ciReleaseKey.current.algorithm;
-  happyCiKeyPublicNonEmpty = (builtins.stringLength happy.nixfleet.trust.ciReleaseKey.current.public) > 0;
-  happyAtticKey = happy.nixfleet.trust.atticCacheKey.current;
-  happyOrgKeyDefaultsToNull = happy.nixfleet.trust.orgRootKey.current;
-  assertionsDeclared = builtins.length happy.assertions;
+  # P-256 fixture — covers the TPM-backed path.
+  happyP256CiKeyAlgorithm = happyP256.nixfleet.trust.ciReleaseKey.current.algorithm;
+  happyP256CiKeyPublicNonEmpty = (builtins.stringLength happyP256.nixfleet.trust.ciReleaseKey.current.public) > 0;
+
+  # ed25519 fixture — covers the HSM / YubiKey / software-key path,
+  # asserting the submodule accepts both algorithms symmetrically.
+  happyEd25519CiKeyAlgorithm = happyEd25519.nixfleet.trust.ciReleaseKey.current.algorithm;
+  happyEd25519CiKeyPublicNonEmpty = (builtins.stringLength happyEd25519.nixfleet.trust.ciReleaseKey.current.public) > 0;
+
+  happyAtticKey = happyP256.nixfleet.trust.atticCacheKey.current;
+  happyOrgKeyDefaultsToNull = happyP256.nixfleet.trust.orgRootKey.current;
+  assertionsDeclared = builtins.length happyP256.assertions;
 }


### PR DESCRIPTION
## Summary

Stream B follow-up to the §I/§II multi-algorithm signing amendment (#18, merged in \`786c248\`).

Widens \`lib.withSignature\` to accept an optional \`signatureAlgorithm\` argument so Stream A's CI can stamp \`meta.signatureAlgorithm\` when signing with non-default algorithms. The M70q TPM emits \`ecdsa-p256\`; future installs on HSM / YubiKey can keep the default (unset ⇒ ed25519 per §I #1).

Also extends the trust-options eval test to cover both \`ed25519\` and \`ecdsa-p256\` public-key declarations symmetrically — the prior test only exercised \`ecdsa-p256\` in its happy path.

## What changed

### \`lib/mkFleet.nix\`

\`\`\`nix
withSignature = {
  signedAt,
  ciCommit,
  signatureAlgorithm ? null,
}: resolved:
  resolved
  // {
    meta =
      resolved.meta
      // {inherit signedAt ciCommit;}
      // lib.optionalAttrs (signatureAlgorithm != null) {inherit signatureAlgorithm;};
  };
\`\`\`

Behavior verified via \`nix eval\`:

- Omitted arg → \`meta\` keeps only \`{schemaVersion, signedAt, ciCommit}\` (backward compatible; absent ⇒ ed25519 per §I #1).
- \`signatureAlgorithm = "ecdsa-p256"\` → \`meta.signatureAlgorithm = "ecdsa-p256"\` stamped.
- \`signatureAlgorithm = "ed25519"\` → \`meta.signatureAlgorithm = "ed25519"\` stamped (explicit, for consumers that prefer not to rely on the default).

### \`modules/tests/_trust-options.nix\`

Refactored to evaluate the trust module against two fixtures via a shared \`evalTrustWith\` helper:

- \`happyP256\` — TPM-backed path (ecdsa-p256 current key).
- \`happyEd25519\` — HSM / YubiKey / software-key path (ed25519 current key).

Both assert \`algorithm\` and non-empty \`public\` are accepted through the same submodule.

## Verification

\`\`\`
$ nix flake check --no-build
→ exit 0

$ nix eval --impure --json --expr 'import ./modules/tests/_trust-options.nix { ... }'
{
  "assertionsDeclared": 3,
  "happyAtticKey": "attic:cache.example.com:AAAA...",
  "happyEd25519CiKeyAlgorithm": "ed25519",
  "happyEd25519CiKeyPublicNonEmpty": true,
  "happyP256CiKeyAlgorithm": "ecdsa-p256",
  "happyP256CiKeyPublicNonEmpty": true,
  "happyOrgKeyDefaultsToNull": null
}

$ nix eval --impure --json --expr '<withSignature 3-case smoke>'
# Confirms absent / ed25519 / ecdsa-p256 all behave as expected.
\`\`\`

## Test plan

- [ ] \`nix flake check\` passes (eval + VM tests)
- [ ] \`modules/tests/_trust-options.nix\` returns both P-256 and ed25519 algorithms
- [ ] \`withSignature\` with no \`signatureAlgorithm\` produces backward-compatible meta (no \`signatureAlgorithm\` key)
- [ ] \`withSignature\` with explicit \`signatureAlgorithm\` stamps the value into meta

## Downstream

- Stream A's CI can now call \`nixfleet.lib.withSignature { signedAt = ...; ciCommit = ...; signatureAlgorithm = "ecdsa-p256"; } resolved\` when the TPM keyslot emits P-256. Absent argument stays ed25519 per the §I #1 default.
- Stream C's verifier reads \`meta.signatureAlgorithm\` (default \`"ed25519"\` if absent) and branches verifier backend accordingly.

Refs: #18.