### PR TITLE
feat(flake): expose nixfleet-canonicalize as package + app

### DIFF
--- a/crane-workspace.nix
+++ b/crane-workspace.nix
@@ -97,6 +97,18 @@
       };
     });
 
+  nixfleet-canonicalize = craneLib.buildPackage (commonArgs
+    // {
+      pname = "nixfleet-canonicalize";
+      cargoExtraArgs = "-p nixfleet-canonicalize";
+      src = fileSetForCrate {crate = ./crates/nixfleet-canonicalize;};
+      meta = {
+        description = "JCS (RFC 8785) canonicalizer pinned per CONTRACTS.md §III";
+        license = lib.licenses.asl20;
+        mainProgram = "nixfleet-canonicalize";
+      };
+    });
+
   # Layer 3: workspace tests - one run covering all crates.
   workspace-tests = craneLib.cargoTest {
     inherit cargoArtifacts;
@@ -106,6 +118,6 @@
     cargoExtraArgs = "--workspace --locked";
   };
 in {
-  packages = {inherit nixfleet-agent nixfleet-control-plane nixfleet-cli;};
+  packages = {inherit nixfleet-agent nixfleet-control-plane nixfleet-cli nixfleet-canonicalize;};
   checks = {inherit workspace-tests;};
 }

--- a/modules/rust-packages.nix
+++ b/modules/rust-packages.nix
@@ -27,6 +27,12 @@
       meta.description = "NixFleet fleet management CLI";
     };
 
+    apps.nixfleet-canonicalize = {
+      type = "app";
+      program = "${workspace.packages.nixfleet-canonicalize}/bin/nixfleet-canonicalize";
+      meta.description = "JCS canonicalizer — invoked by CI before signing (CONTRACTS.md §III)";
+    };
+
     devShells.default = craneLib.devShell {
       checks = workspace.checks;
       packages = with pkgs; [


### PR DESCRIPTION
The \`nixfleet-canonicalize\` binary is needed by Stream A's CI after stamping meta fields and before signing \`fleet.resolved\` (CONTRACTS.md §III). Currently the crate exists and passes workspace tests, but is not exposed as a flake package or app — CI cannot \`nix run .#nixfleet-canonicalize\`.

## Changes

- \`crane-workspace.nix\`: add a \`craneLib.buildPackage\` entry mirroring the existing agent/CP/CLI pattern; add \`nixfleet-canonicalize\` to the exposed \`packages\` attrset.
- \`modules/rust-packages.nix\`: add \`apps.nixfleet-canonicalize\` registration for \`nix run\`.

## Verification

Eval check on this branch:

\`\`\`
\$ nix flake check --no-build
(exit 0)

\$ nix eval --impure --expr 'builtins.attrNames (builtins.getFlake (toString ./.)).packages.x86_64-linux'
[ "nixfleet-agent" "nixfleet-canonicalize" "nixfleet-cli" "nixfleet-control-plane" ]

\$ nix eval --impure --expr 'builtins.attrNames (builtins.getFlake (toString ./.)).apps.x86_64-linux'
[ "agent" "build-vm" "clean-vm" "control-plane" "nixfleet" "nixfleet-canonicalize" ... ]
\`\`\`

## Consumer

Once merged, abstracts33d/fleet#... (feat/v0.2-ci-canonicalize-swap) bumps its flake.lock and uses \`nix run .#nixfleet-canonicalize\` in the CI workflow.

No changes to the crate itself — this is pure packaging.