### PR TITLE
docs: cross-ref audit + docs/README.md index

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ nix develop  # enters the dev shell with Rust toolchain, cargo, rustfmt, clippy
 
 ## Project Structure
 
-See [README.md](README.md#layout) for the directory layout.
+See [README.md](README.md#architecture) for the directory layout.
 
 ## Running Tests
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,54 @@
+# nixfleet documentation
+
+Map of what lives where. Every doc here is authoritative for its topic; when
+the code disagrees, the code is being built to match.
+
+## Design + contracts (read first)
+
+| File | What it is | When to read |
+|---|---|---|
+| [`../ARCHITECTURE.md`](../ARCHITECTURE.md) | High-level architecture, component roles, trust flow, build order (Phases 0–10) | First read for new contributors |
+| [`CONTRACTS.md`](CONTRACTS.md) | Every artifact, key, and format that crosses a stream boundary (data, trust roots, canonicalization, storage purity) | When adding or changing anything cross-stream |
+| [`KICKOFF.md`](KICKOFF.md) | v0.2 cycle flow, stream prompts (A / B / C), checkpoints, merge discipline | When starting work on a v0.2 stream |
+
+## Protocol + data (RFCs)
+
+| File | Topic |
+|---|---|
+| [`../rfcs/0001-fleet-nix.md`](../rfcs/0001-fleet-nix.md) | Declarative fleet shape: `mkFleet`, selectors, rollouts, edges, budgets, `fleet.resolved` artifact |
+| [`../rfcs/0002-reconciler.md`](../rfcs/0002-reconciler.md) | Reconciler state machine, decision procedure, verify path, failure handling |
+| [`../rfcs/0003-protocol.md`](../rfcs/0003-protocol.md) | Agent ↔ control-plane wire protocol, identity model, endpoints, security model |
+
+## Operational reference (mdbook)
+
+The [`mdbook/`](mdbook/) subtree is the user-facing manual built with mdbook.
+Start at [`mdbook/README.md`](mdbook/README.md); the full table of contents
+lives in [`mdbook/SUMMARY.md`](mdbook/SUMMARY.md). Notable sections:
+
+| Section | Path |
+|---|---|
+| Architecture overview | [`mdbook/architecture.md`](mdbook/architecture.md) |
+| Getting started (quick start, installation, design guarantees) | [`mdbook/guide/getting-started/`](mdbook/guide/getting-started/) |
+| Defining hosts (`mkHost`, hostSpec, cross-platform) | [`mdbook/guide/defining-hosts/`](mdbook/guide/defining-hosts/) |
+| Deploying (control plane, agent, cache, rollouts) | [`mdbook/guide/deploying/`](mdbook/guide/deploying/) |
+| Operating (status, rollback, impermanence) | [`mdbook/guide/operating/`](mdbook/guide/operating/) |
+| Extending (custom scopes, secrets, templates) | [`mdbook/guide/extending/`](mdbook/guide/extending/) |
+| Reference (CLI, options, modules) | [`mdbook/reference/`](mdbook/reference/) |
+| Testing (overview, eval, VM, Rust) | [`mdbook/testing/`](mdbook/testing/) |
+
+## Historical decisions
+
+| File | What it is |
+|---|---|
+| [`adr/`](adr/) | Architecture Decision Records (011 ADRs, numbered 001–011) covering `mkHost`, flags-over-roles, agent-as-service-module, hydration, fire-and-forget apply, etc. |
+| [`superpowers/`](superpowers/) | Spec + plan artifacts from implementation cycles (`specs/`, `plans/`) |
+
+## Root-level docs
+
+| File | What it is |
+|---|---|
+| [`../README.md`](../README.md) | User-facing README: install, quick start, ecosystem |
+| [`../CHANGELOG.md`](../CHANGELOG.md) | Changelog (Keep a Changelog format) |
+| [`../CONTRIBUTING.md`](../CONTRIBUTING.md) | Contributor guide: setup, tests, commit conventions, license |
+| [`../SECURITY.md`](../SECURITY.md) | Security policy and disclosure |
+| [`../CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) | Code of conduct |

--- a/docs/mdbook/architecture.md
+++ b/docs/mdbook/architecture.md
@@ -106,7 +106,7 @@ Fleet repos add their own inputs as needed (e.g. `agenix` or `sops-nix` for secr
 
 ## Design Decisions
 
-Key architectural decisions are documented in [Architecture Decision Records](adr/).
+Key architectural decisions are documented in [Architecture Decision Records](../adr/).
 
 Summary of foundational decisions:
 


### PR DESCRIPTION
Low-risk doc hygiene pass. Background agent ran the audit; I reviewed the diff and it's clean.

## What changed

Two broken cross-refs fixed:

| File | Before | After |
|---|---|---|
| \`docs/mdbook/architecture.md\` | \`[ADR](adr/)\` resolved to nonexistent \`docs/mdbook/adr/\` | \`../adr/\` |
| \`CONTRIBUTING.md\` | \`README.md#layout\` (no such heading) | \`README.md#architecture\` |

New \`docs/README.md\` — 5-section index (design+contracts, RFCs, operational mdbook, historical ADRs, root docs). 22 internal links, all resolve.

## Flagged but not fixed (reviewer's judgement call — left alone per scope)

- \`docs/KICKOFF.md:169\` references \`modules/trust.nix\`; actual file is \`modules/_trust.nix\`. Forward-looking milestone reference — touching KICKOFF was out of scope for the audit. Worth a follow-up edit if the \`_\` prefix convention is intentional (it is — per nixfleet project conventions).
- \`docs/KICKOFF.md:214,223\` references \`bin/nixfleet-canonicalize\`; actual crate is \`crates/nixfleet-canonicalize\`. Forward-looking CI tool reference.
- \`docs/KICKOFF.md:220\` references \`docs/CP-STORAGE.md\` which Stream C's M1P3 (#29) is slated to produce.

## Verification

\`\`\`
nix flake check --no-build
\`\`\`

Docs-only; all updated links verified resolvable.