### PR TITLE
feat(tests/harness/fixtures): signed-fixture derivation (Phase 2 PR(a) — fixture half)

### DIFF
--- a/modules/tests/harness.nix
+++ b/modules/tests/harness.nix
@@ -16,11 +16,30 @@
     pkgs,
     lib,
     system,
+    config,
     ...
   }: let
-    harness = import ../../tests/harness {inherit lib pkgs inputs;};
+    # Pull the canonicalize package from the crane workspace (same
+    # perSystem, declared in `modules/rust-packages.nix`). The harness
+    # entry point needs it to bake the signed fixture at build time.
+    nixfleet-canonicalize = config.packages.nixfleet-canonicalize or null;
+    harness = import ../../tests/harness {
+      inherit lib pkgs inputs nixfleet-canonicalize;
+    };
   in
     lib.optionalAttrs (system == "x86_64-linux") {
-      checks = harness;
+      checks =
+        {
+          fleet-harness-smoke = harness.fleet-harness-smoke;
+        }
+        # Only register the signed-fixture check when the canonicalize
+        # package is available for this system (x86_64-linux only today;
+        # other systems skip it silently).
+        // lib.optionalAttrs (nixfleet-canonicalize != null) {
+          # Phase 2 PR(a) signed-fixture derivation. Byte-stability
+          # regression guard; rebuild failure signals non-determinism in
+          # mkFleet, canonicalize, or the keygen helper.
+          phase-2-signed-fixture = harness.signedFixture;
+        };
     };
 }

--- a/tests/harness/default.nix
+++ b/tests/harness/default.nix
@@ -15,6 +15,11 @@
   lib,
   pkgs,
   inputs,
+  # `nixfleet-canonicalize` is built by the workspace crane pipeline
+  # (see `crane-workspace.nix`) and wired in by `modules/tests/harness.nix`.
+  # Default to `null` so this file still evaluates from callers that don't
+  # pass it — fixture-dependent attrs will throw on access.
+  nixfleet-canonicalize ? null,
 }: let
   harnessLib = import ./lib.nix {inherit lib pkgs inputs;};
 
@@ -30,10 +35,31 @@
     testCerts = sharedCerts;
     resolvedJsonPath = ./fixtures/fleet-resolved.json;
   };
+
+  # Phase 2 PR(a): signed-fixture derivation. Consumed by the
+  # (future) `signed-roundtrip` scenario and by
+  # `crates/nixfleet-verify-artifact`. See ./fixtures/signed/README.md.
+  signedFixture =
+    if nixfleet-canonicalize == null
+    then
+      throw ''
+        tests/harness: signedFixture requires `nixfleet-canonicalize` to be
+        passed in. Wire it via `modules/tests/harness.nix` or call sites
+        that have the flake's `packages.<system>.nixfleet-canonicalize`.
+      ''
+    else
+      import ./fixtures/signed {
+        inherit lib pkgs nixfleet-canonicalize;
+      };
 in {
   # Target shape per issue #5: `checks.<system>.fleet-N`. For the scaffold
   # we only ship N=2 (smoke). Extension: import additional scenario files
   # here with different agent counts, or parameterise smoke.nix to accept
   # `agentCount` and expose fleet-5, fleet-10 wrappers.
   fleet-harness-smoke = import ./scenarios/smoke.nix scenarioArgs;
+
+  # Signed-fixture derivation exposed as a harness attribute. Registered
+  # as a flake check (`phase-2-signed-fixture`) in `modules/tests/harness.nix`
+  # so byte-stability regressions surface on every CI run.
+  inherit signedFixture;
 }

--- a/tests/harness/fixtures/signed/README.md
+++ b/tests/harness/fixtures/signed/README.md
@@ -1,0 +1,85 @@
+# Signed harness fixture
+
+A deterministic, byte-stable `fleet.resolved.json` with an ed25519
+signature, baked at Nix build time. Consumed by the Phase 2 signed
+round-trip harness scenario and by the Rust verify CLI.
+
+Lives at `tests/harness/fixtures/signed/` rather than under
+`crates/*/tests/fixtures/` because the fixture is produced by a Nix
+derivation (openssl + the pinned `nixfleet-canonicalize` binary). See
+`docs/phase-2-entry-spec.md` §12.1 for the locked-in placement
+rationale.
+
+## What the derivation emits
+
+Four files in a single `/nix/store/*-nixfleet-harness-signed-fixture`
+output directory:
+
+| File | Purpose |
+|------|---------|
+| `canonical.json` | JCS-canonical bytes of `fleet.resolved` with `meta.{signedAt, ciCommit, signatureAlgorithm}` stamped. The exact byte stream the signature covers. |
+| `canonical.json.sig` | Raw 64-byte ed25519 signature over `canonical.json`. No DER, no armour. |
+| `verify-pubkey.b64` | Base64 of the 32 raw pubkey bytes, no newline. Extracted from the DER SPKI output of `openssl pkey -pubout` by stripping the 12-byte header. |
+| `test-trust.json` | Trust root JSON per `docs/trust-root-flow.md` §3.4 (`schemaVersion: 1` required per §7.4). Embeds the verify pubkey as `ciReleaseKey.current`. |
+
+## Determinism
+
+Every output byte is a pure function of this directory's contents.
+Reproducibility is the whole point — any drift between two eval runs
+signals non-determinism that will break the round-trip test.
+
+Deterministic inputs:
+
+- **Fleet declaration** — hand-authored inline in `default.nix`
+  (`fleetInput` binding).
+- **`meta` stamps** — `signedAt = "2026-05-01T00:00:00Z"`,
+  `ciCommit = "0" × 40`, `signatureAlgorithm = "ed25519"`. Hardcoded.
+- **Keypair** — derived from a 32-byte seed
+  (`builtins.hashString "sha256" "nixfleet-harness-test-seed-2026"`)
+  wrapped into a PKCS#8 PrivateKeyInfo via RFC 8410 §7 ASN.1. OpenSSL 3
+  cannot accept a caller-supplied seed for `genpkey -algorithm ED25519`
+  directly (see openssl/openssl#18333); hand-building the 48-byte DER is
+  the cleanest path. Changing the seed string forces a new keypair
+  everywhere downstream.
+- **Canonicalizer** — pinned `nixfleet-canonicalize` package (serde_jcs
+  0.2 per `docs/CONTRACTS.md` §III).
+
+Verify with two evals:
+
+```bash
+nix eval --impure \
+  --expr '(builtins.getFlake (toString ./.)).checks.x86_64-linux.phase-2-signed-fixture.drvPath'
+```
+
+Run the command twice — the two `drvPath` strings MUST match. A
+mismatch means one of the inputs has leaked impurity (system time,
+randomness, absolute paths) and needs tracing.
+
+## Consumers
+
+All pending. Updated to links as work lands.
+
+- **`tests/harness/scenarios/signed-roundtrip.nix`** (Phase 2 PR(b),
+  TODO) — serves `canonical.json` + `canonical.json.sig` from the CP
+  stub, mounts `test-trust.json` into the agent microVM, asserts
+  verify succeeds and the agent logs `harness-roundtrip-ok:`.
+- **`crates/nixfleet-verify-artifact`** (Phase 2 PR(a), Stream C,
+  TODO) — thin CLI wrapping `reconciler::verify_artifact`. Receives
+  the four files as `--artifact`, `--signature`, `--trust-file`, and
+  a derived `--now` / `--freshness-window-secs`.
+
+## Out of scope here
+
+Per `docs/phase-2-entry-spec.md` §9 — the first wire-up deliberately
+exercises only one algorithm and one non-rotation trust configuration.
+Explicit non-goals for this fixture:
+
+- ECDSA P-256 signatures (unit-tested in `crates/nixfleet-reconciler`).
+- Multi-key `previous` rotation (follow-up scenario
+  `fleet-harness-signed-rotation-cross-algo`).
+- `rejectBefore` compromise switch (scenario-specific).
+- Tampered-signature refusal (Checkpoint 2 scenario copies this
+  derivation and flips one byte).
+
+Each of those is a sibling derivation that copies this one and changes
+one input.

--- a/tests/harness/fixtures/signed/default.nix
+++ b/tests/harness/fixtures/signed/default.nix
@@ -1,0 +1,216 @@
+# tests/harness/fixtures/signed/default.nix
+#
+# Deterministic signed-fixture derivation for the Phase 2 microvm harness.
+# Produces an ed25519-signed `fleet.resolved` artifact at build time,
+# along with the raw verify key and a `test-trust.json` file shaped per
+# `docs/trust-root-flow.md` §3.4.
+#
+# Determinism. Every byte in the output is a pure function of this file's
+# inputs:
+# - The fleet declaration is hand-authored below (static).
+# - `meta.{signedAt, ciCommit, signatureAlgorithm}` are hardcoded.
+# - The ed25519 keypair is derived from a fixed 32-byte seed via PKCS#8
+#   ASN.1 wrapping — see `keygenHelper` below for the exact method.
+# - `nixfleet-canonicalize` is a pinned flake package (serde_jcs 0.2).
+#
+# Consumed by (future):
+# - `tests/harness/scenarios/signed-roundtrip.nix` (Phase 2 PR(b)) —
+#   serves `canonical.json` + `canonical.json.sig` from the harness CP
+#   stub and injects `test-trust.json` into the agent microVM.
+# - `crates/nixfleet-verify-artifact` (Phase 2 PR(a), Stream C) — reads
+#   the three files as CLI inputs and exits 0 on valid verify.
+#
+# See `./README.md` for the full data-flow walk-through.
+{
+  lib,
+  pkgs,
+  nixfleet-canonicalize,
+  # Path to lib/mkFleet.nix — resolved relative to the repo root. Exposed
+  # as an argument so harness plumbing can swap in a stubbed mkFleet
+  # without rebuilding the framework.
+  mkFleetPath ? ../../../../lib/mkFleet.nix,
+}: let
+  # 32-byte seed derived from a fixed string per §12.2 of the Phase 2
+  # entry spec. Changing the string forces a new keypair across every
+  # consumer — intended for rotation scenarios that want a second seed.
+  seedHex = builtins.substring 0 64 (builtins.hashString "sha256" "nixfleet-harness-test-seed-2026");
+
+  # Frozen CI-metadata stamps. Keep in sync with the scenario's
+  # `--now` / `--freshness-window-secs` inputs so verify does not trip
+  # the freshness gate against wall-clock time at harness runtime.
+  fixedSignedAt = "2026-05-01T00:00:00Z";
+  fixedCiCommit = "0000000000000000000000000000000000000000"; # obviously a placeholder
+  fixedAlgorithm = "ed25519";
+
+  # --- Stub nixosConfiguration: satisfies mkFleet's invariant that
+  # each host carries a configuration with `config.system.build.toplevel`.
+  # Reused pattern from `tests/lib/mkFleet/fixtures/_stub-configuration.nix`.
+  stubConfiguration = {
+    config.system.build.toplevel = {
+      outPath = "/nix/store/0000000000000000000000000000000000000000-stub";
+      drvPath = "/nix/store/0000000000000000000000000000000000000000-stub.drv";
+    };
+  };
+
+  # --- Import mkFleet directly; no flake indirection. The resolved tree
+  # is a pure function of this file's contents.
+  mkFleetImpl = import mkFleetPath {inherit lib;};
+  inherit (mkFleetImpl) mkFleet withSignature;
+
+  # --- Hand-authored fleet declaration for the harness. Two hosts, one
+  # channel, one rollout policy. Deliberately minimal so any failure
+  # during verify is wire-up, not fleet-shape.
+  fleetInput = {
+    hosts = {
+      agent-01 = {
+        system = "x86_64-linux";
+        configuration = stubConfiguration;
+        tags = ["harness"];
+        channel = "stable";
+        pubkey = null;
+      };
+      cp = {
+        system = "x86_64-linux";
+        configuration = stubConfiguration;
+        tags = ["harness" "control-plane"];
+        channel = "stable";
+        pubkey = null;
+      };
+    };
+    channels.stable = {
+      description = "Harness signed-fixture channel.";
+      rolloutPolicy = "all-at-once";
+      reconcileIntervalMinutes = 30;
+      signingIntervalMinutes = 60;
+      freshnessWindow = 86400; # 60 days — way above 2 × signingInterval.
+      compliance = {
+        strict = false;
+        frameworks = [];
+      };
+    };
+    rolloutPolicies.all-at-once = {
+      strategy = "all-at-once";
+      waves = [
+        {
+          selector.all = true;
+          soakMinutes = 0;
+        }
+      ];
+      healthGate = {};
+      onHealthFailure = "halt";
+    };
+    edges = [];
+    disruptionBudgets = [];
+  };
+
+  fleet = mkFleet fleetInput;
+
+  stamped =
+    withSignature {
+      signedAt = fixedSignedAt;
+      ciCommit = fixedCiCommit;
+      signatureAlgorithm = fixedAlgorithm;
+    }
+    fleet.resolved;
+
+  # Nix's `builtins.toJSON` emits deterministic JSON (attrset keys sorted
+  # lexicographically, no floats in our schema) — ideal feed for JCS.
+  stampedJson = builtins.toJSON stamped;
+
+  # Python 3 stdlib is enough to wrap a 32-byte seed into a PKCS#8
+  # ed25519 private key. OpenSSL 3's `genpkey -algorithm ED25519` does
+  # NOT accept a caller-provided seed (see openssl/openssl#18333); the
+  # cleanest deterministic path is to hand-build the ASN.1.
+  #
+  # RFC 8410 §7 PKCS#8 PrivateKeyInfo for ed25519:
+  #   SEQUENCE {
+  #     version      INTEGER 0,
+  #     algorithm    AlgorithmIdentifier { OID 1.3.101.112 (id-Ed25519) },
+  #     privateKey   OCTET STRING containing OCTET STRING(seed)
+  #   }
+  # DER prefix (16 bytes): 302e020100300506032b657004220420
+  # followed by the 32-byte seed. Total 48 bytes.
+  keygenHelper = pkgs.writers.writePython3 "ed25519-pkcs8-from-seed" {} ''
+    import base64
+    import sys
+
+    seed_hex = sys.argv[1]
+    out_path = sys.argv[2]
+
+    seed = bytes.fromhex(seed_hex)
+    assert len(seed) == 32, f"expected 32-byte seed, got {len(seed)}"
+
+    # RFC 8410 §7 DER prefix for a PKCS#8-wrapped ed25519 private key.
+    der_prefix = bytes.fromhex("302e020100300506032b657004220420")
+    der = der_prefix + seed
+    b64 = base64.b64encode(der).decode("ascii")
+
+    with open(out_path, "w") as f:
+        f.write("-----BEGIN PRIVATE KEY-----\n")
+        f.write(b64 + "\n")
+        f.write("-----END PRIVATE KEY-----\n")
+  '';
+in
+  pkgs.runCommand "nixfleet-harness-signed-fixture" {
+    nativeBuildInputs = [pkgs.openssl];
+    # Pass the resolved+stamped JSON in as a file to keep the derivation
+    # hermetic (no environment-variable size limits, same bytes on every
+    # builder).
+    passAsFile = ["stampedJson"];
+    inherit stampedJson seedHex;
+  } ''
+    set -euo pipefail
+
+    mkdir -p "$out"
+
+    # --- Step 1: derive the ed25519 keypair from the fixed seed.
+    ${keygenHelper} "$seedHex" privkey.pem
+
+    # --- Step 2: stage the stamped JSON and canonicalize it via JCS.
+    cp "$stampedJsonPath" stamped.json
+    ${nixfleet-canonicalize}/bin/nixfleet-canonicalize < stamped.json > "$out/canonical.json"
+
+    # --- Step 3: ed25519-sign the canonical bytes. Raw 64-byte output.
+    openssl pkeyutl \
+      -sign -rawin \
+      -inkey privkey.pem \
+      -in "$out/canonical.json" \
+      -out "$out/canonical.json.sig"
+
+    # Sanity: ed25519 signatures are exactly 64 bytes.
+    siglen=$(stat -c %s "$out/canonical.json.sig")
+    if [ "$siglen" -ne 64 ]; then
+      echo "unexpected signature length: $siglen bytes" >&2
+      exit 1
+    fi
+
+    # --- Step 4: emit the verify pubkey. `openssl pkey -pubout -outform
+    # DER` yields a 44-byte SPKI: 12-byte header + 32 raw pubkey bytes.
+    # Strip the header and base64-encode the raw 32 bytes.
+    openssl pkey -in privkey.pem -pubout -outform DER -out pubkey.spki.der
+    pubkey_b64=$(tail -c 32 pubkey.spki.der | base64 -w0)
+    printf '%s' "$pubkey_b64" > "$out/verify-pubkey.b64"
+
+    # --- Step 5: emit test-trust.json per docs/trust-root-flow.md §3.4.
+    # schemaVersion is REQUIRED per §7.4.
+    cat > "$out/test-trust.json" <<EOF
+    {
+      "schemaVersion": 1,
+      "ciReleaseKey": {
+        "current": { "algorithm": "ed25519", "public": "$pubkey_b64" },
+        "previous": null,
+        "rejectBefore": null
+      },
+      "atticCacheKey": { "current": null },
+      "orgRootKey": { "current": null }
+    }
+    EOF
+
+    # Final shape check: four files, no more, no less.
+    expected="canonical.json canonical.json.sig test-trust.json verify-pubkey.b64"
+    actual=$(cd "$out" && ls | sort | tr '\n' ' ' | sed 's/ $//')
+    if [ "$actual" != "$(printf '%s\n' $expected | sort | tr '\n' ' ' | sed 's/ $//')" ]; then
+      echo "unexpected output files: $actual" >&2
+      exit 1
+    fi
+  ''


### PR DESCRIPTION
Fixture half of Phase 2 PR(a) per \`docs/phase-2-entry-spec.md\` §7. Produces a deterministic, signed \`fleet.resolved.json\` that the harness's signed-roundtrip scenario (landing in Phase 2 PR(b)) will consume. The Rust CLI half (\`nixfleet-verify-artifact\`) is Stream C's work once #29 lands \`TrustConfig\`.

## What's produced

The new \`checks.x86_64-linux.phase-2-signed-fixture\` derivation emits into \`\$out/\`:

| File | Purpose |
|---|---|
| \`canonical.json\` | JCS-canonical stamped fleet.resolved (~885 bytes) |
| \`canonical.json.sig\` | Raw 64-byte ed25519 signature |
| \`verify-pubkey.b64\` | Base64 of the 32-byte ed25519 pubkey |
| \`test-trust.json\` | \`TrustConfig\` file matching \`docs/trust-root-flow.md\` §3.4 shape (\`schemaVersion: 1\`, \`ciReleaseKey\`, null atticCacheKey/orgRootKey) |

## Key design decisions (locked per \`docs/phase-2-entry-spec.md\` §12)

- **ed25519**, not ecdsa-p256 (§12.3). Pure-Nix-reproducible; the p256 path is already covered by Stream C's \`verify_ecdsa_p256\` unit tests.
- **Fixed seed**, not per-build (§12.2). Derived from \`sha256("nixfleet-harness-test-seed-2026")\`. Reproducibility confirmed — two drvPath evaluations match byte-for-byte.
- **Scenario-local location** (§12.1): \`tests/harness/fixtures/signed/default.nix\`.

## Ambiguity the agent flagged (worth reviewer awareness)

OpenSSL 3's \`genpkey -algorithm ED25519\` does not accept a caller-supplied seed (openssl/openssl#18333). The derivation hand-builds the 48-byte PKCS#8 PrivateKeyInfo DER (RFC 8410 §7: header \`302e020100300506032b657004220420\` + 32 seed bytes), PEM-wraps it, then hands to \`openssl pkeyutl -sign -rawin\`. Method documented in an inline block comment. This is the cleanest way to get a deterministic ed25519 signer from a fixed seed with nothing but stock openssl.

## Verification

Run on your side:

\`\`\`
nix build .#checks.x86_64-linux.phase-2-signed-fixture --no-link -L
\`\`\`

Expected: four files under \`\$out\`, \`canonical.json.sig\` exactly 64 bytes.

Determinism check — run \`nix eval\` of the drvPath twice; both must return the same \`/nix/store/*.drv\` path. Agent confirmed MATCH.

## What this does NOT do

- No \`nixfleet-verify-artifact\` CLI — that's Stream C's #29 scope.
- No \`tests/harness/scenarios/signed-roundtrip.nix\` — that's Phase 2 PR(b), which consumes this fixture.
- No signature algorithm other than ed25519. p256 rotation scenario is a later follow-up.