### PR TITLE
Phase 2: verify-artifact CLI + signed-roundtrip harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1519,6 +1519,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nixfleet-verify-artifact"
+version = "0.2.0"
+dependencies = [
+ "chrono",
+ "clap",
+ "nixfleet-proto",
+ "nixfleet-reconciler",
+ "serde_json",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crane-workspace.nix
+++ b/crane-workspace.nix
@@ -102,6 +102,18 @@
       };
     });
 
+  nixfleet-verify-artifact = craneLib.buildPackage (commonArgs
+    // {
+      pname = "nixfleet-verify-artifact";
+      cargoExtraArgs = "-p nixfleet-verify-artifact";
+      src = fileSetForCrate {crate = ./crates/nixfleet-verify-artifact;};
+      meta = {
+        description = "Phase 2 harness CLI wrapping nixfleet_reconciler::verify_artifact";
+        license = lib.licenses.mit;
+        mainProgram = "nixfleet-verify-artifact";
+      };
+    });
+
   workspace-tests = craneLib.cargoTest {
     inherit cargoArtifacts;
     src = workspaceSrc;
@@ -110,6 +122,6 @@
     cargoExtraArgs = "--workspace --locked";
   };
 in {
-  packages = {inherit nixfleet-agent nixfleet-control-plane nixfleet-cli nixfleet-canonicalize;};
+  packages = {inherit nixfleet-agent nixfleet-control-plane nixfleet-cli nixfleet-canonicalize nixfleet-verify-artifact;};
   checks = {inherit workspace-tests;};
 }

--- a/crates/nixfleet-proto/src/lib.rs
+++ b/crates/nixfleet-proto/src/lib.rs
@@ -30,4 +30,4 @@ pub use fleet_resolved::{
     Channel, Compliance, ComplianceProbes, DisruptionBudget, Edge, FleetResolved, HealthGate, Host,
     Meta, PolicyWave, RolloutPolicy, Selector, SystemdFailedUnits, Wave,
 };
-pub use trust::{AtticKeySlot, KeySlot, TrustConfig, TrustedPubkey};
+pub use trust::{AtticKeySlot, AtticPubkey, KeySlot, TrustConfig, TrustedPubkey};

--- a/crates/nixfleet-proto/src/trust.rs
+++ b/crates/nixfleet-proto/src/trust.rs
@@ -129,12 +129,52 @@ impl KeySlot {
     }
 }
 
-/// Attic cache key in the attic-native string format `"attic:<host>:<base64>"`.
+/// Attic cache key material in the attic-native string format
+/// `"attic:<host>:<base64>"`.
 ///
-/// Typed as an opaque newtype because Stream B's `modules/_trust.nix`
-/// currently keeps the attic key flat (CONTRACTS.md §II #2 has not yet
-/// been migrated to the `{algorithm, public}` shape that §II #1 uses).
-/// Migrates to `KeySlot<AtticPubkey>` when §II #2 gains that treatment.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+/// Typed as an opaque newtype over `String`: attic's own signing model
+/// encodes host and key bytes inside the string, so splitting it into
+/// `{algorithm, public}` would be redundant with attic-side parsing.
+/// Consumers forward the raw string to attic tooling at closure-verify
+/// time.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(transparent)]
-pub struct AtticKeySlot(pub String);
+pub struct AtticPubkey(pub String);
+
+/// A single attic-cache trust slot with rotation grace + compromise
+/// switch. Shape mirrors [`KeySlot`] — same `current` / `previous` /
+/// `reject_before` semantics — except key material is an opaque
+/// [`AtticPubkey`] rather than a `{algorithm, public}` pair.
+///
+/// A two-key active window supports the 30-day dual-accept rotation
+/// grace documented in CONTRACTS.md §II #2: agents treat closures
+/// signed under either `current` or `previous` as trusted until the
+/// operator closes the window by setting `previous` back to `None`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AtticKeySlot {
+    #[serde(default)]
+    pub current: Option<AtticPubkey>,
+
+    #[serde(default)]
+    pub previous: Option<AtticPubkey>,
+
+    #[serde(default)]
+    pub reject_before: Option<DateTime<Utc>>,
+}
+
+impl AtticKeySlot {
+    /// Returns the active key list for this slot. Both `current` and
+    /// `previous` are returned unconditionally when present, in that
+    /// order — matches the first-match semantics of [`KeySlot::active_keys`].
+    pub fn active_keys(&self) -> Vec<AtticPubkey> {
+        let mut keys = Vec::with_capacity(2);
+        if let Some(k) = &self.current {
+            keys.push(k.clone());
+        }
+        if let Some(k) = &self.previous {
+            keys.push(k.clone());
+        }
+        keys
+    }
+}

--- a/crates/nixfleet-proto/tests/trust_config.rs
+++ b/crates/nixfleet-proto/tests/trust_config.rs
@@ -2,7 +2,7 @@
 //!
 //! Shape authoritative per docs/trust-root-flow.md §3.4 + §7.4.
 
-use nixfleet_proto::{AtticKeySlot, KeySlot, TrustConfig, TrustedPubkey};
+use nixfleet_proto::{AtticKeySlot, AtticPubkey, KeySlot, TrustConfig, TrustedPubkey};
 
 #[test]
 fn trust_config_roundtrips_minimum_shape() {
@@ -58,10 +58,33 @@ fn key_slot_active_keys_skips_absent() {
 }
 
 #[test]
-fn attic_key_slot_accepts_native_format() {
+fn attic_pubkey_accepts_native_format() {
     let json = r#""attic:cache.example.com:AAAA""#;
+    let pk: AtticPubkey = serde_json::from_str(json).unwrap();
+    assert_eq!(pk.0, "attic:cache.example.com:AAAA");
+}
+
+#[test]
+fn attic_key_slot_roundtrips_populated_shape() {
+    let json = r#"{
+        "current": "attic:cache.example.com:AAAA",
+        "previous": "attic:cache.example.com:BBBB",
+        "rejectBefore": null
+    }"#;
     let slot: AtticKeySlot = serde_json::from_str(json).unwrap();
-    assert_eq!(slot.0, "attic:cache.example.com:AAAA");
+    let keys = slot.active_keys();
+    assert_eq!(keys.len(), 2);
+    assert_eq!(keys[0].0, "attic:cache.example.com:AAAA");
+    assert_eq!(keys[1].0, "attic:cache.example.com:BBBB");
+    assert!(slot.reject_before.is_none());
+}
+
+#[test]
+fn attic_key_slot_empty_object_is_empty() {
+    let json = r#"{ "current": null, "previous": null, "rejectBefore": null }"#;
+    let slot: AtticKeySlot = serde_json::from_str(json).unwrap();
+    assert!(slot.active_keys().is_empty());
+    assert!(slot.reject_before.is_none());
 }
 
 #[test]

--- a/crates/nixfleet-verify-artifact/Cargo.toml
+++ b/crates/nixfleet-verify-artifact/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "nixfleet-verify-artifact"
+version = "0.2.0"
+edition = "2021"
+description = "Thin CLI wrapping nixfleet_reconciler::verify_artifact (harness scaffold, Phase 2 PR(a))"
+license = "MIT"
+repository = "https://github.com/arcanesys/nixfleet"
+homepage = "https://github.com/arcanesys/nixfleet"
+authors = ["nixfleet contributors"]
+
+[[bin]]
+name = "nixfleet-verify-artifact"
+path = "src/main.rs"
+
+[dependencies]
+nixfleet-proto = { path = "../nixfleet-proto" }
+nixfleet-reconciler = { path = "../nixfleet-reconciler" }
+chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "4", features = ["derive"] }
+serde_json = "1"

--- a/crates/nixfleet-verify-artifact/src/main.rs
+++ b/crates/nixfleet-verify-artifact/src/main.rs
@@ -1,0 +1,122 @@
+//! `nixfleet-verify-artifact` — thin CLI wrapping
+//! `nixfleet_reconciler::verify_artifact`.
+//!
+//! Harness scaffold per `docs/phase-2-entry-spec.md §6`. Exists purely so
+//! the Phase 2 signed-roundtrip scenario can call `verify_artifact` from
+//! a shell-friendly entry point before Stream C's v0.2 agent takes over
+//! the same call site. Retire this crate once the agent inlines
+//! `verify_artifact` internally.
+//!
+//! Exit codes (per spec §6):
+//! - 0 — artifact verified
+//! - 1 — verify error (stderr carries the `VerifyError` variant + detail)
+//! - 2 — argument / I/O / parse error
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use clap::Parser;
+use nixfleet_proto::TrustConfig;
+use nixfleet_reconciler::verify_artifact;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "nixfleet-verify-artifact",
+    about = "Verify a signed fleet.resolved artifact against a trust.json file.",
+    version
+)]
+struct Args {
+    /// Path to the canonical (JCS) signed artifact bytes.
+    #[arg(long)]
+    artifact: PathBuf,
+
+    /// Path to the raw signature bytes (64 bytes for ed25519 / ecdsa-p256).
+    #[arg(long)]
+    signature: PathBuf,
+
+    /// Path to the trust.json file (shape per docs/trust-root-flow.md §3.4).
+    #[arg(long)]
+    trust_file: PathBuf,
+
+    /// Reference timestamp for the freshness check (RFC 3339).
+    #[arg(long)]
+    now: DateTime<Utc>,
+
+    /// Maximum age (in seconds) of `meta.signedAt` relative to `--now`.
+    #[arg(long)]
+    freshness_window_secs: u64,
+}
+
+fn main() -> ExitCode {
+    let args = Args::parse();
+
+    let artifact = match std::fs::read(&args.artifact) {
+        Ok(v) => v,
+        Err(err) => {
+            eprintln!("read artifact {}: {err}", args.artifact.display());
+            return ExitCode::from(2);
+        }
+    };
+    let signature = match std::fs::read(&args.signature) {
+        Ok(v) => v,
+        Err(err) => {
+            eprintln!("read signature {}: {err}", args.signature.display());
+            return ExitCode::from(2);
+        }
+    };
+    let trust_raw = match std::fs::read_to_string(&args.trust_file) {
+        Ok(v) => v,
+        Err(err) => {
+            eprintln!("read trust-file {}: {err}", args.trust_file.display());
+            return ExitCode::from(2);
+        }
+    };
+
+    let trust: TrustConfig = match serde_json::from_str(&trust_raw) {
+        Ok(t) => t,
+        Err(err) => {
+            eprintln!("parse trust-file {}: {err}", args.trust_file.display());
+            return ExitCode::from(2);
+        }
+    };
+
+    // trust.json §7.4 requires schemaVersion 1; refuse unknown versions
+    // at the CLI boundary so operators see a clear arg-level failure
+    // rather than a downstream verify error.
+    if trust.schema_version != TrustConfig::CURRENT_SCHEMA_VERSION {
+        eprintln!(
+            "trust-file schemaVersion {} unsupported (accepted: {})",
+            trust.schema_version,
+            TrustConfig::CURRENT_SCHEMA_VERSION
+        );
+        return ExitCode::from(2);
+    }
+
+    let trusted_keys = trust.ci_release_key.active_keys();
+    let reject_before = trust.ci_release_key.reject_before;
+    let freshness_window = Duration::from_secs(args.freshness_window_secs);
+
+    match verify_artifact(
+        &artifact,
+        &signature,
+        &trusted_keys,
+        args.now,
+        freshness_window,
+        reject_before,
+    ) {
+        Ok(fleet) => {
+            println!(
+                "schemaVersion={} hosts={}",
+                fleet.schema_version,
+                fleet.hosts.len()
+            );
+            ExitCode::SUCCESS
+        }
+        Err(err) => {
+            eprintln!("{err}");
+            ExitCode::from(1)
+        }
+    }
+}

--- a/crates/nixfleet-verify-artifact/tests/parse_fixture_trust.rs
+++ b/crates/nixfleet-verify-artifact/tests/parse_fixture_trust.rs
@@ -1,0 +1,29 @@
+//! Sanity check: the exact `test-trust.json` shape emitted by
+//! `tests/harness/fixtures/signed/default.nix` must deserialize with
+//! `TrustConfig`. Smoke-tests the contract between the harness
+//! fixture (Stream A output) and the proto crate (Stream C input)
+//! before the full signed-roundtrip scenario lands.
+
+use nixfleet_proto::TrustConfig;
+
+#[test]
+fn trust_json_from_fixture_shape_parses() {
+    // Byte-identical to the HEREDOC in tests/harness/fixtures/signed/default.nix
+    // (step 5) with a placeholder pubkey. If the fixture changes, update here.
+    let raw = r#"
+    {
+      "schemaVersion": 1,
+      "ciReleaseKey": {
+        "current": { "algorithm": "ed25519", "public": "PLACEHOLDER_PUBKEY_BASE64" },
+        "previous": null,
+        "rejectBefore": null
+      },
+      "atticCacheKey": { "current": null },
+      "orgRootKey": { "current": null }
+    }
+    "#;
+
+    let parsed: TrustConfig = serde_json::from_str(raw).expect("trust.json parses");
+    assert_eq!(parsed.schema_version, 1);
+    assert!(parsed.ci_release_key.current.is_some());
+}

--- a/docs/trust-root-flow.md
+++ b/docs/trust-root-flow.md
@@ -91,7 +91,7 @@ in {
 }
 ```
 
-The file is world-readable (contains only public keys — by definition not secret). `atticCacheKey` uses the attic-native `"attic:<host>:<base64>"` string format, not the typed submodule — Stream B's `modules/_trust.nix` currently types only `ciReleaseKey` per CONTRACTS §II #1; the attic key stays flat until §II #2 gains similar treatment.
+The file is world-readable (contains only public keys — by definition not secret). `atticCacheKey` and `orgRootKey` both emit as `{current, previous, rejectBefore}` slot objects: key material stays in its algorithm's native format (attic-native `"attic:<host>:<base64>"` strings under `atticCacheKey`; typed `{algorithm, public}` submodules under `orgRootKey`), but both slots expose the same rotation-grace + compromise-switch surface that `ciReleaseKey` uses.
 
 ### 3.3 CP binary CLI surface
 
@@ -164,7 +164,7 @@ impl KeySlot {
 }
 ```
 
-`AtticKeySlot` is a separate newtype for now (flat string format) — migrates to `KeySlot` when §II #2 gets the same `{algorithm, public}` treatment as §II #1.
+`AtticKeySlot` mirrors `KeySlot`'s shape (`current` / `previous` / `rejectBefore`) with an `AtticPubkey(String)` newtype holding attic-native `"attic:<host>:<base64>"` material instead of a `{algorithm, public}` pair. Agents forward the raw string to attic tooling at closure-verify time.
 
 ### 3.5 Verify call site
 

--- a/modules/rust-packages.nix
+++ b/modules/rust-packages.nix
@@ -33,6 +33,12 @@
       meta.description = "JCS canonicalizer — invoked by CI before signing (CONTRACTS.md §III)";
     };
 
+    apps.nixfleet-verify-artifact = {
+      type = "app";
+      program = "${workspace.packages.nixfleet-verify-artifact}/bin/nixfleet-verify-artifact";
+      meta.description = "Phase 2 harness CLI — verify a signed fleet.resolved against a trust.json";
+    };
+
     devShells.default = craneLib.devShell {
       checks = workspace.checks;
       packages = with pkgs; [

--- a/modules/scopes/nixfleet/_trust-json.nix
+++ b/modules/scopes/nixfleet/_trust-json.nix
@@ -3,17 +3,17 @@
 # TrustConfig — see crates/nixfleet-proto/src/trust.rs and
 # docs/trust-root-flow.md §3.4.
 #
-# The proto expects typed `{algorithm, public}` submodules for keys in
-# KeySlot. modules/_trust.nix declares `ciReleaseKey` that way already,
-# but `orgRootKey` still uses the legacy bare-string keySlotType (per
-# CONTRACTS §II #3 org root keys are always ed25519, so a single string
-# was sufficient). This helper promotes the bare-string slot into the
-# proto struct shape so the binaries can deserialize the emission.
+# `ciReleaseKey` is already in proto shape on the option side (typed
+# {algorithm, public} submodules per CONTRACTS §II #1) and passes
+# through unchanged.
 #
-# `atticCacheKey` emits as a flat string (only `.current`) per proto's
-# AtticKeySlot(String) newtype — see docs/trust-root-flow.md §3.2.
-# Rotation for the attic key is handled by re-signing the closure
-# history, not by a second active key, so `.previous` is unused on wire.
+# `atticCacheKey` and `orgRootKey` store bare-string key material on the
+# option side (keySlotType in modules/_trust.nix). They're pinned to one
+# algorithm each per CONTRACTS §II #2 (attic-native) / §II #3 (ed25519),
+# so the algorithm doesn't need to be declared per-slot. This helper
+# emits both slots as `{current, previous, rejectBefore}` objects
+# matching proto's AtticKeySlot / KeySlot shape, and promotes orgRootKey
+# strings into typed TrustedPubkey entries.
 {trust}: let
   wrapEd25519 = key:
     if key == null
@@ -25,7 +25,11 @@
 in {
   schemaVersion = 1;
   ciReleaseKey = trust.ciReleaseKey;
-  atticCacheKey = trust.atticCacheKey.current;
+  atticCacheKey = {
+    current = trust.atticCacheKey.current;
+    previous = trust.atticCacheKey.previous;
+    rejectBefore = trust.atticCacheKey.rejectBefore;
+  };
   orgRootKey = {
     current = wrapEd25519 trust.orgRootKey.current;
     previous = wrapEd25519 trust.orgRootKey.previous;

--- a/modules/tests/harness.nix
+++ b/modules/tests/harness.nix
@@ -19,12 +19,15 @@
     config,
     ...
   }: let
-    # Pull the canonicalize package from the crane workspace (same
-    # perSystem, declared in `modules/rust-packages.nix`). The harness
-    # entry point needs it to bake the signed fixture at build time.
+    # Pull crane-built packages from the workspace (same perSystem,
+    # declared in `modules/rust-packages.nix`). The harness entry point
+    # uses `nixfleet-canonicalize` to bake the signed fixture and
+    # `nixfleet-verify-artifact` as the binary the signed-roundtrip
+    # agent microVM runs.
     nixfleet-canonicalize = config.packages.nixfleet-canonicalize or null;
+    nixfleet-verify-artifact = config.packages.nixfleet-verify-artifact or null;
     harness = import ../../tests/harness {
-      inherit lib pkgs inputs nixfleet-canonicalize;
+      inherit lib pkgs inputs nixfleet-canonicalize nixfleet-verify-artifact;
     };
   in
     lib.optionalAttrs (system == "x86_64-linux") {
@@ -40,6 +43,12 @@
           # regression guard; rebuild failure signals non-determinism in
           # mkFleet, canonicalize, or the keygen helper.
           phase-2-signed-fixture = harness.signedFixture;
+        }
+        // lib.optionalAttrs (nixfleet-canonicalize != null && nixfleet-verify-artifact != null) {
+          # Phase 2 PR(b) signed-roundtrip scenario. Exercises the full
+          # stack: fixture build -> mTLS serve -> agent fetch ->
+          # verify_artifact accept -> OK marker.
+          fleet-harness-signed-roundtrip = harness.fleet-harness-signed-roundtrip;
         };
     };
 }

--- a/tests/harness/default.nix
+++ b/tests/harness/default.nix
@@ -20,6 +20,10 @@
   # Default to `null` so this file still evaluates from callers that don't
   # pass it — fixture-dependent attrs will throw on access.
   nixfleet-canonicalize ? null,
+  # `nixfleet-verify-artifact` is built by the same crane pipeline. The
+  # signed-roundtrip scenario invokes it from inside the agent microVM;
+  # the smoke scenario does not need it.
+  nixfleet-verify-artifact ? null,
 }: let
   harnessLib = import ./lib.nix {inherit lib pkgs inputs;};
 
@@ -37,8 +41,8 @@
   };
 
   # Phase 2 PR(a): signed-fixture derivation. Consumed by the
-  # (future) `signed-roundtrip` scenario and by
-  # `crates/nixfleet-verify-artifact`. See ./fixtures/signed/README.md.
+  # `signed-roundtrip` scenario and by `crates/nixfleet-verify-artifact`.
+  # See ./fixtures/signed/README.md.
   signedFixture =
     if nixfleet-canonicalize == null
     then
@@ -51,12 +55,32 @@
       import ./fixtures/signed {
         inherit lib pkgs nixfleet-canonicalize;
       };
+
+  # Phase 2 PR(b): signed-roundtrip scenario. Depends on both
+  # `signedFixture` (fixture bytes + trust.json) and
+  # `nixfleet-verify-artifact` (the CLI the agent microVM runs).
+  signedRoundtripScenario =
+    if nixfleet-verify-artifact == null
+    then
+      throw ''
+        tests/harness: fleet-harness-signed-roundtrip requires
+        `nixfleet-verify-artifact` to be passed in. Wire it via
+        `modules/tests/harness.nix` using the crane-built package.
+      ''
+    else
+      import ./scenarios/signed-roundtrip.nix (scenarioArgs
+        // {
+          inherit signedFixture;
+          verifyArtifactPkg = nixfleet-verify-artifact;
+        });
 in {
   # Target shape per issue #5: `checks.<system>.fleet-N`. For the scaffold
   # we only ship N=2 (smoke). Extension: import additional scenario files
   # here with different agent counts, or parameterise smoke.nix to accept
   # `agentCount` and expose fleet-5, fleet-10 wrappers.
   fleet-harness-smoke = import ./scenarios/smoke.nix scenarioArgs;
+
+  fleet-harness-signed-roundtrip = signedRoundtripScenario;
 
   # Signed-fixture derivation exposed as a harness attribute. Registered
   # as a flake check (`phase-2-signed-fixture`) in `modules/tests/harness.nix`

--- a/tests/harness/lib.nix
+++ b/tests/harness/lib.nix
@@ -111,6 +111,18 @@
     _module.args = {inherit testCerts resolvedJsonPath;};
   };
 
+  # Signed-fixture CP: routes GET /canonical.json + /canonical.json.sig
+  # from `signedFixture` (the derivation output at
+  # tests/harness/fixtures/signed/default.nix). Used only by the
+  # signed-roundtrip scenario; the smoke scenario keeps `mkCpHostModule`.
+  mkSignedCpHostModule = {
+    testCerts,
+    signedFixture,
+  }: {
+    imports = [./nodes/cp-signed.nix];
+    _module.args = {inherit testCerts signedFixture;};
+  };
+
   mkAgentNode = {
     testCerts,
     hostName,
@@ -126,6 +138,51 @@
 
     _module.args = {
       inherit testCerts controlPlaneHost controlPlanePort;
+      harnessMicrovmDefaults = microvmGuestDefaults;
+      agentHostName = hostName;
+    };
+
+    networking.hostName = hostName;
+    system.stateVersion = lib.mkDefault "24.11";
+  };
+
+  # Verifying agent: fetches canonical.json + .sig from the signed CP,
+  # loads /etc/nixfleet-harness/test-trust.json from `signedFixture`,
+  # invokes the `nixfleet-verify-artifact` binary from
+  # `verifyArtifactPkg` (crane-built) and logs the OK marker on success.
+  #
+  # `now` and `freshnessWindowSecs` defaults are scoped so the
+  # freshness-window check always passes against the fixture's frozen
+  # `signedAt = 2026-05-01T00:00:00Z`:
+  #   now − signedAt = 3600s (1h) << window = 604800s (7d).
+  # Checkpoint 2 scenarios override these to assert Stale refusal.
+  mkVerifyingAgentNode = {
+    testCerts,
+    hostName,
+    signedFixture,
+    verifyArtifactPkg,
+    controlPlaneHost ? "10.0.2.2",
+    controlPlanePort ? 8443,
+    now ? "2026-05-01T01:00:00Z",
+    freshnessWindowSecs ? 604800,
+    extraModules ? [],
+  }: {
+    imports =
+      [
+        ./nodes/agent-verify.nix
+      ]
+      ++ extraModules;
+
+    _module.args = {
+      inherit
+        testCerts
+        controlPlaneHost
+        controlPlanePort
+        signedFixture
+        verifyArtifactPkg
+        now
+        freshnessWindowSecs
+        ;
       harnessMicrovmDefaults = microvmGuestDefaults;
       agentHostName = hostName;
     };
@@ -180,5 +237,13 @@
       meta.timeout = timeout;
     };
 in {
-  inherit mkAgentNode mkCpHostModule mkFleetScenario mkHarnessCerts microvmGuestDefaults;
+  inherit
+    mkAgentNode
+    mkCpHostModule
+    mkFleetScenario
+    mkHarnessCerts
+    mkSignedCpHostModule
+    mkVerifyingAgentNode
+    microvmGuestDefaults
+    ;
 }

--- a/tests/harness/nodes/agent-verify.nix
+++ b/tests/harness/nodes/agent-verify.nix
@@ -1,0 +1,108 @@
+# tests/harness/nodes/agent-verify.nix
+#
+# Signed-roundtrip agent microVM. At boot, fetches `canonical.json` and
+# `canonical.json.sig` from the CP over mTLS, stages `test-trust.json`
+# from the signed fixture, then runs `nixfleet-verify-artifact`. On
+# successful verify the unit emits `harness-roundtrip-ok:
+# schemaVersion=<n> hosts=<n>` — the scenario testScript greps for the
+# marker.
+#
+# TODO: retire this module when the v0.2 agent inlines the verify call
+# site (per docs/phase-2-entry-spec.md §6 — the CLI is scaffold).
+{
+  lib,
+  pkgs,
+  testCerts,
+  controlPlaneHost,
+  controlPlanePort,
+  harnessMicrovmDefaults,
+  agentHostName,
+  signedFixture,
+  verifyArtifactPkg,
+  # Fixed timestamps chosen so the freshness-window check always passes
+  # against the fixture's frozen `signedAt = 2026-05-01T00:00:00Z`:
+  #   now − signedAt = 3600s (1h) << freshnessWindow = 604800s (7d).
+  # See tests/harness/fixtures/signed/default.nix for the stamp source.
+  # Defaults live in mkVerifyingAgentNode, not here: NixOS's module
+  # system resolves function arguments through `_module.args` and does
+  # not consult module-function defaults.
+  now,
+  freshnessWindowSecs,
+  ...
+}: {
+  microvm = harnessMicrovmDefaults;
+
+  environment.etc = {
+    "nixfleet-harness/ca.pem".source = "${testCerts}/ca.pem";
+    "nixfleet-harness/${agentHostName}-cert.pem".source = "${testCerts}/${agentHostName}-cert.pem";
+    "nixfleet-harness/${agentHostName}-key.pem".source = "${testCerts}/${agentHostName}-key.pem";
+    "nixfleet-harness/test-trust.json".source = "${signedFixture}/test-trust.json";
+  };
+
+  systemd.services.harness-agent = {
+    description = "Nixfleet harness agent (verifies signed artifact)";
+    wantedBy = ["multi-user.target"];
+    after = ["network.target"];
+    path = [pkgs.curl pkgs.coreutils verifyArtifactPkg];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      StandardOutput = "journal+console";
+      StandardError = "journal+console";
+      ExecStart = pkgs.writeShellScript "harness-agent-verify" ''
+        set -euo pipefail
+
+        base="https://cp:${toString controlPlanePort}"
+        workdir=$(mktemp -d)
+        trap 'rm -rf "$workdir"' EXIT
+
+        fetch() {
+          local url_path="$1" out="$2"
+          curl -sfS \
+            --cacert /etc/nixfleet-harness/ca.pem \
+            --cert /etc/nixfleet-harness/${agentHostName}-cert.pem \
+            --key /etc/nixfleet-harness/${agentHostName}-key.pem \
+            --resolve "cp:${toString controlPlanePort}:${controlPlaneHost}" \
+            --connect-timeout 30 \
+            --max-time 60 \
+            "$base$url_path" -o "$out"
+        }
+
+        echo "harness-agent: fetching signed artifact from $base" >&2
+        if ! fetch /canonical.json "$workdir/artifact"; then
+          echo "harness-roundtrip-FAIL: canonical.json fetch failed" >&2
+          exit 1
+        fi
+        if ! fetch /canonical.json.sig "$workdir/signature"; then
+          echo "harness-roundtrip-FAIL: canonical.json.sig fetch failed" >&2
+          exit 1
+        fi
+
+        sig_len=$(stat -c %s "$workdir/signature")
+        if [ "$sig_len" != 64 ]; then
+          echo "harness-roundtrip-FAIL: expected 64-byte signature, got $sig_len" >&2
+          exit 1
+        fi
+
+        echo "harness-agent: running nixfleet-verify-artifact" >&2
+        verify_out=$(nixfleet-verify-artifact \
+          --artifact "$workdir/artifact" \
+          --signature "$workdir/signature" \
+          --trust-file /etc/nixfleet-harness/test-trust.json \
+          --now ${now} \
+          --freshness-window-secs ${toString freshnessWindowSecs})
+
+        # Belt-and-suspenders: also write to /dev/console so the marker
+        # reaches the host journal even if journald forwarding from the
+        # guest is disabled (same pattern as nodes/agent.nix).
+        msg="harness-roundtrip-ok: $verify_out"
+        echo "$msg" >&2
+        echo "$msg" > /dev/console || true
+      '';
+      Restart = "on-failure";
+      RestartSec = 5;
+    };
+  };
+
+  system.stateVersion = lib.mkDefault "24.11";
+}

--- a/tests/harness/nodes/cp-signed.nix
+++ b/tests/harness/nodes/cp-signed.nix
@@ -35,59 +35,65 @@
   networking.firewall.allowedTCPPorts = [8443];
 
   systemd.services.harness-cp = let
-    server = pkgs.writers.writePython3 "harness-cp-signed-server" {} ''
-      import ssl
-      import sys
-      from http.server import BaseHTTPRequestHandler, HTTPServer
+    server =
+      pkgs.writers.writePython3 "harness-cp-signed-server" {
+        # Route-table line for canonical.json.sig nudges past flake8's
+        # 79-char default. This is harness glue, not production Python —
+        # readability > line length.
+        flakeIgnore = ["E501"];
+      } ''
+        import ssl
+        import sys
+        from http.server import BaseHTTPRequestHandler, HTTPServer
 
-      BASE = "/etc/nixfleet-harness/signed"
-      ROUTES = {
-          "/canonical.json": (f"{BASE}/canonical.json", "application/json"),
-          "/canonical.json.sig": (f"{BASE}/canonical.json.sig", "application/octet-stream"),
-      }
-
-
-      class Handler(BaseHTTPRequestHandler):
-          protocol_version = "HTTP/1.1"
-
-          def do_GET(self):
-              entry = ROUTES.get(self.path)
-              if entry is None:
-                  self.send_response(404)
-                  self.send_header("Content-Length", "0")
-                  self.send_header("Connection", "close")
-                  self.end_headers()
-                  return
-              path, ctype = entry
-              with open(path, "rb") as f:
-                  data = f.read()
-              self.send_response(200)
-              self.send_header("Content-Type", ctype)
-              self.send_header("Content-Length", str(len(data)))
-              self.send_header("Connection", "close")
-              self.end_headers()
-              self.wfile.write(data)
-
-          def log_message(self, fmt, *args):
-              sys.stderr.write("harness-cp: " + (fmt % args) + "\n")
+        BASE = "/etc/nixfleet-harness/signed"
+        ROUTES = {
+            "/canonical.json": (f"{BASE}/canonical.json", "application/json"),
+            "/canonical.json.sig": (f"{BASE}/canonical.json.sig", "application/octet-stream"),
+        }
 
 
-      def main():
-          ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-          ctx.load_cert_chain(
-              certfile="/etc/nixfleet-harness/cp-cert.pem",
-              keyfile="/etc/nixfleet-harness/cp-key.pem",
-          )
-          ctx.load_verify_locations(cafile="/etc/nixfleet-harness/ca.pem")
-          ctx.verify_mode = ssl.CERT_REQUIRED
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
 
-          httpd = HTTPServer(("0.0.0.0", 8443), Handler)
-          httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
-          httpd.serve_forever()
+            def do_GET(self):
+                entry = ROUTES.get(self.path)
+                if entry is None:
+                    self.send_response(404)
+                    self.send_header("Content-Length", "0")
+                    self.send_header("Connection", "close")
+                    self.end_headers()
+                    return
+                path, ctype = entry
+                with open(path, "rb") as f:
+                    data = f.read()
+                self.send_response(200)
+                self.send_header("Content-Type", ctype)
+                self.send_header("Content-Length", str(len(data)))
+                self.send_header("Connection", "close")
+                self.end_headers()
+                self.wfile.write(data)
+
+            def log_message(self, fmt, *args):
+                sys.stderr.write("harness-cp: " + (fmt % args) + "\n")
 
 
-      main()
-    '';
+        def main():
+            ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            ctx.load_cert_chain(
+                certfile="/etc/nixfleet-harness/cp-cert.pem",
+                keyfile="/etc/nixfleet-harness/cp-key.pem",
+            )
+            ctx.load_verify_locations(cafile="/etc/nixfleet-harness/ca.pem")
+            ctx.verify_mode = ssl.CERT_REQUIRED
+
+            httpd = HTTPServer(("0.0.0.0", 8443), Handler)
+            httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
+            httpd.serve_forever()
+
+
+        main()
+      '';
   in {
     description = "Nixfleet harness CP stub (serves signed fixture — canonical.json + .sig, Python mTLS)";
     wantedBy = ["multi-user.target"];

--- a/tests/harness/nodes/cp-signed.nix
+++ b/tests/harness/nodes/cp-signed.nix
@@ -1,0 +1,82 @@
+# tests/harness/nodes/cp-signed.nix
+#
+# Signed-roundtrip CP node. Serves two files from the Phase 2 signed
+# fixture over mTLS on :8443, routed by request path:
+#
+#   GET /canonical.json      -> application/json
+#   GET /canonical.json.sig  -> application/octet-stream (raw 64 bytes)
+#
+# Unlike the unsigned stub in `cp.nix`, this responder streams the file
+# body with `cat` instead of slurping through `$(...)` — the signature
+# is binary and contains null bytes, which shell command substitution
+# mangles on every implementation except bash 5+.
+#
+# TODO: retire this module when `services.nixfleet-control-plane`
+# gains the artifact-serve endpoint. The wire shape (two paths, mTLS,
+# path-routed) is the real CP's contract.
+{
+  lib,
+  pkgs,
+  testCerts,
+  signedFixture,
+  ...
+}: {
+  environment.etc = {
+    "nixfleet-harness/ca.pem".source = "${testCerts}/ca.pem";
+    "nixfleet-harness/cp-cert.pem".source = "${testCerts}/cp-cert.pem";
+    "nixfleet-harness/cp-key.pem".source = "${testCerts}/cp-key.pem";
+    "nixfleet-harness/signed/canonical.json".source = "${signedFixture}/canonical.json";
+    "nixfleet-harness/signed/canonical.json.sig".source = "${signedFixture}/canonical.json.sig";
+  };
+
+  networking.firewall.allowedTCPPorts = [8443];
+
+  systemd.services.harness-cp = let
+    responder = pkgs.writeShellScript "harness-cp-signed-responder" ''
+      set -eu
+      export PATH=${lib.makeBinPath [pkgs.coreutils]}:$PATH
+
+      # First line is "METHOD PATH VERSION\r". Drop the trailing CR.
+      IFS=' ' read -r _method path _version
+      path="''${path%$(printf '\r')}"
+
+      dir=/etc/nixfleet-harness/signed
+      case "$path" in
+        /canonical.json)     file="$dir/canonical.json";     ct="application/json" ;;
+        /canonical.json.sig) file="$dir/canonical.json.sig"; ct="application/octet-stream" ;;
+        *)
+          printf 'HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'
+          exit 0
+          ;;
+      esac
+
+      len=$(stat -c %s "$file")
+      printf 'HTTP/1.1 200 OK\r\nContent-Type: %s\r\nContent-Length: %d\r\nConnection: close\r\n\r\n' "$ct" "$len"
+      cat "$file"
+    '';
+    socatOpts = lib.concatStringsSep "," [
+      "OPENSSL-LISTEN:8443"
+      "reuseaddr"
+      "fork"
+      "cert=/etc/nixfleet-harness/cp-cert.pem"
+      "key=/etc/nixfleet-harness/cp-key.pem"
+      "cafile=/etc/nixfleet-harness/ca.pem"
+      "verify=1"
+    ];
+    launcher = pkgs.writeShellScript "harness-cp-signed-launcher" ''
+      exec ${pkgs.socat}/bin/socat -v "${socatOpts}" "EXEC:${responder}"
+    '';
+  in {
+    description = "Nixfleet harness CP stub (serves signed fixture — canonical.json + .sig)";
+    wantedBy = ["multi-user.target"];
+    after = ["network.target"];
+    serviceConfig = {
+      Type = "simple";
+      ExecStart = "${launcher}";
+      Restart = "on-failure";
+      RestartSec = 2;
+    };
+  };
+
+  system.stateVersion = lib.mkDefault "24.11";
+}

--- a/tests/harness/nodes/cp-signed.nix
+++ b/tests/harness/nodes/cp-signed.nix
@@ -6,17 +6,20 @@
 #   GET /canonical.json      -> application/json
 #   GET /canonical.json.sig  -> application/octet-stream (raw 64 bytes)
 #
-# Unlike the unsigned stub in `cp.nix`, this responder streams the file
-# body with `cat` instead of slurping through `$(...)` — the signature
-# is binary and contains null bytes, which shell command substitution
-# mangles on every implementation except bash 5+.
+# Implementation: Python stdlib `http.server` wrapped in `ssl`. An
+# earlier shell-over-socat implementation truncated binary responses:
+# even with request draining and `exec cat`, the socat EXEC pipeline
+# consistently delivered 54 of the signature's 64 bytes to the client,
+# though socat's own `-v` log confirmed the full 64 bytes had been
+# forwarded. The exact mangling point was never identified; the fix
+# was to stop debugging shell and ship a binary-safe server.
 #
 # TODO: retire this module when `services.nixfleet-control-plane`
 # gains the artifact-serve endpoint. The wire shape (two paths, mTLS,
 # path-routed) is the real CP's contract.
 {
-  lib,
   pkgs,
+  lib,
   testCerts,
   signedFixture,
   ...
@@ -32,47 +35,66 @@
   networking.firewall.allowedTCPPorts = [8443];
 
   systemd.services.harness-cp = let
-    responder = pkgs.writeShellScript "harness-cp-signed-responder" ''
-      set -eu
-      export PATH=${lib.makeBinPath [pkgs.coreutils]}:$PATH
+    server = pkgs.writers.writePython3 "harness-cp-signed-server" {} ''
+      import ssl
+      import sys
+      from http.server import BaseHTTPRequestHandler, HTTPServer
 
-      # First line is "METHOD PATH VERSION\r". Drop the trailing CR.
-      IFS=' ' read -r _method path _version
-      path="''${path%$(printf '\r')}"
+      BASE = "/etc/nixfleet-harness/signed"
+      ROUTES = {
+          "/canonical.json": (f"{BASE}/canonical.json", "application/json"),
+          "/canonical.json.sig": (f"{BASE}/canonical.json.sig", "application/octet-stream"),
+      }
 
-      dir=/etc/nixfleet-harness/signed
-      case "$path" in
-        /canonical.json)     file="$dir/canonical.json";     ct="application/json" ;;
-        /canonical.json.sig) file="$dir/canonical.json.sig"; ct="application/octet-stream" ;;
-        *)
-          printf 'HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'
-          exit 0
-          ;;
-      esac
 
-      len=$(stat -c %s "$file")
-      printf 'HTTP/1.1 200 OK\r\nContent-Type: %s\r\nContent-Length: %d\r\nConnection: close\r\n\r\n' "$ct" "$len"
-      cat "$file"
-    '';
-    socatOpts = lib.concatStringsSep "," [
-      "OPENSSL-LISTEN:8443"
-      "reuseaddr"
-      "fork"
-      "cert=/etc/nixfleet-harness/cp-cert.pem"
-      "key=/etc/nixfleet-harness/cp-key.pem"
-      "cafile=/etc/nixfleet-harness/ca.pem"
-      "verify=1"
-    ];
-    launcher = pkgs.writeShellScript "harness-cp-signed-launcher" ''
-      exec ${pkgs.socat}/bin/socat -v "${socatOpts}" "EXEC:${responder}"
+      class Handler(BaseHTTPRequestHandler):
+          protocol_version = "HTTP/1.1"
+
+          def do_GET(self):
+              entry = ROUTES.get(self.path)
+              if entry is None:
+                  self.send_response(404)
+                  self.send_header("Content-Length", "0")
+                  self.send_header("Connection", "close")
+                  self.end_headers()
+                  return
+              path, ctype = entry
+              with open(path, "rb") as f:
+                  data = f.read()
+              self.send_response(200)
+              self.send_header("Content-Type", ctype)
+              self.send_header("Content-Length", str(len(data)))
+              self.send_header("Connection", "close")
+              self.end_headers()
+              self.wfile.write(data)
+
+          def log_message(self, fmt, *args):
+              sys.stderr.write("harness-cp: " + (fmt % args) + "\n")
+
+
+      def main():
+          ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+          ctx.load_cert_chain(
+              certfile="/etc/nixfleet-harness/cp-cert.pem",
+              keyfile="/etc/nixfleet-harness/cp-key.pem",
+          )
+          ctx.load_verify_locations(cafile="/etc/nixfleet-harness/ca.pem")
+          ctx.verify_mode = ssl.CERT_REQUIRED
+
+          httpd = HTTPServer(("0.0.0.0", 8443), Handler)
+          httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
+          httpd.serve_forever()
+
+
+      main()
     '';
   in {
-    description = "Nixfleet harness CP stub (serves signed fixture — canonical.json + .sig)";
+    description = "Nixfleet harness CP stub (serves signed fixture — canonical.json + .sig, Python mTLS)";
     wantedBy = ["multi-user.target"];
     after = ["network.target"];
     serviceConfig = {
       Type = "simple";
-      ExecStart = "${launcher}";
+      ExecStart = "${server}";
       Restart = "on-failure";
       RestartSec = 2;
     };

--- a/tests/harness/scenarios/signed-roundtrip.nix
+++ b/tests/harness/scenarios/signed-roundtrip.nix
@@ -1,0 +1,75 @@
+# tests/harness/scenarios/signed-roundtrip.nix
+#
+# Phase 2 cross-stream wire-up test per docs/phase-2-entry-spec.md §1–3.
+#
+# Proves that one signed fleet.resolved.json round-trips through:
+#   mkFleet -> withSignature -> nixfleet-canonicalize -> ed25519-sign
+#   (fixture build)
+#   -> CP mTLS serve -> agent mTLS fetch
+#   -> nixfleet-verify-artifact (trust.json + verify_artifact) -> ok marker
+#
+# Failure in any step surfaces as either `harness-roundtrip-FAIL:` (fetch
+# / shape error, surfaced before verify) or a `VerifyError` variant on
+# stderr (verify_artifact rejected). Both are visible to the scenario's
+# grep on `harness-roundtrip-ok:`, which never appears in those paths.
+#
+# Sibling-scenario extension path (Checkpoint 2):
+#   - copy this file, tamper one byte in `canonical.json` or `.sig`
+#     before the CP serves it, assert `harness-roundtrip-ok:` does NOT
+#     appear within the deadline -> tamper refusal scenario.
+#   - copy, shift agent's `--now` past `signedAt + freshnessWindow`,
+#     assert Stale -> freshness refusal scenario.
+{
+  harnessLib,
+  testCerts,
+  signedFixture,
+  verifyArtifactPkg,
+  ...
+}: let
+  cpHostModule = harnessLib.mkSignedCpHostModule {
+    inherit testCerts signedFixture;
+  };
+
+  agent = harnessLib.mkVerifyingAgentNode {
+    inherit testCerts signedFixture verifyArtifactPkg;
+    hostName = "agent-01";
+  };
+in
+  harnessLib.mkFleetScenario {
+    name = "fleet-harness-signed-roundtrip";
+    inherit cpHostModule;
+    agents = {agent-01 = agent;};
+    timeout = 600;
+    testScript = ''
+      start_all()
+
+      host.wait_for_unit("multi-user.target")
+      host.wait_for_unit("harness-cp.service")
+      host.wait_for_open_port(8443)
+
+      host.wait_for_unit("microvms.target", timeout=300)
+      host.wait_for_unit("microvm@agent-01.service", timeout=300)
+
+      import time
+      deadline = time.monotonic() + 120
+      while time.monotonic() < deadline:
+          rc, _ = host.execute(
+              "journalctl -u microvm@agent-01.service --no-pager "
+              "| grep -q 'harness-roundtrip-ok:'"
+          )
+          if rc == 0:
+              break
+          time.sleep(2)
+      else:
+          raise Exception("agent did not emit harness-roundtrip-ok within 120s")
+
+      rc, _ = host.execute(
+          "journalctl -u microvm@agent-01.service --no-pager "
+          "| grep -q 'harness-roundtrip-FAIL:'"
+      )
+      if rc == 0:
+          raise Exception("agent emitted harness-roundtrip-FAIL")
+
+      print("fleet-harness-signed-roundtrip: verify_artifact accepted the signed fixture")
+    '';
+  }


### PR DESCRIPTION
## Summary

Lands the consumer-side half of Phase 2 — a cross-stream wire-up that now has a VM-backed regression gate.

- **Proto migration**: `AtticKeySlot` goes from `#[serde(transparent)] String` to a `KeySlot`-shaped struct with `current` / `previous` / `rejectBefore`. The Nix emitter (`modules/scopes/nixfleet/_trust-json.nix`) emits the matching object shape instead of flattening. Unblocks anything that deserializes `test-trust.json`.
- **`nixfleet-verify-artifact` CLI**: new crate, thin wrapper around `nixfleet_reconciler::verify_artifact`. Shape per `docs/phase-2-entry-spec.md §6` / §12.4. Wired through the crane workspace + flake apps.
- **Signed-roundtrip harness scenario**: new `tests/harness/scenarios/signed-roundtrip.nix` + CP / agent node modules. Exercises fixture build → mTLS serve → agent fetch → `verify_artifact` accept → OK marker.

## Status

- `cargo test -p nixfleet-proto -p nixfleet-verify-artifact` — 16 tests green (incl. a regression test pinning the fixture's `test-trust.json` shape against `TrustConfig`).
- `cargo check --workspace` — clean.
- `nix flake check --no-build` — all three harness derivations eval.
- `nix build .#checks.x86_64-linux.fleet-harness-signed-roundtrip` — **green**. Full cross-stream wire verified end-to-end.

## Test plan

- [ ] Reviewer re-runs `nix build .#checks.x86_64-linux.fleet-harness-signed-roundtrip` locally — expect green.
- [ ] `cargo test -p nixfleet-proto` passes with updated `AtticKeySlot` shape.
- [ ] Confirm no out-of-tree consumer touches `AtticKeySlot.0` tuple access (already grep-verified; only the proto's own tests did, now updated).

## Notes

- The CP node's response path went through shell-over-socat originally. Binary payloads (the 64-byte ed25519 signature) truncated to 54 bytes at the client consistently, though socat's own `-v` log confirmed 64 bytes went out. Exact cause not pinned down; responder was rewritten in Python `http.server` + `ssl`, which composes cleanly. See the commit message on the rewrite for the autopsy.
- The CLI crate is scaffold — retire it the moment the v0.2 agent inlines `verify_artifact` directly (per spec §6).