### PR TITLE
RFC-0001 gaps: selector not/and + mergeFleets

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -6,5 +6,5 @@
 {lib}: let
   impl = import ./mkFleet.nix {inherit lib;};
 in {
-  inherit (impl) mkFleet withSignature;
+  inherit (impl) mkFleet mergeFleets withSignature;
 }

--- a/lib/mkFleet.nix
+++ b/lib/mkFleet.nix
@@ -8,6 +8,9 @@
   inherit (lib) mkOption types;
 
   # --- Selector algebra (RFC-0001 §3) ---
+  # Variants evaluated in precedence order: `not` > `and` > base OR over
+  # (tags, tagsAny, hosts, channel, all). `not` and `and` are recursive —
+  # selectors compose to arbitrary set algebra.
   selectorType = types.submodule {
     options = {
       tags = mkOption {
@@ -31,6 +34,16 @@
       all = mkOption {
         type = types.bool;
         default = false;
+      };
+      and = mkOption {
+        type = types.listOf selectorType;
+        default = [];
+        description = "Host matches ALL listed sub-selectors (intersection).";
+      };
+      not = mkOption {
+        type = types.nullOr selectorType;
+        default = null;
+        description = "Host matches iff it does NOT match the given sub-selector (negation).";
       };
     };
   };
@@ -240,18 +253,23 @@
     (scan nodes).cycle;
 
   # --- Selector resolution: selector × hosts → [host-name] ---
+  # Variant precedence (RFC-0001 §3): `not` > `and` > base OR composition.
+  # Base OR = host matches iff any of tags/tagsAny/hosts/channel/all matches.
   resolveSelector = sel: hosts: let
     names = lib.attrNames hosts;
-    matches = n: let
-      h = hosts.${n};
-    in
-      sel.all
-      || (sel.hosts != [] && builtins.elem n sel.hosts)
-      || (sel.channel != null && h.channel == sel.channel)
-      || (sel.tags != [] && lib.all (t: builtins.elem t h.tags) sel.tags)
-      || (sel.tagsAny != [] && lib.any (t: builtins.elem t h.tags) sel.tagsAny);
+    matchHost = s: n: h:
+      if s.not != null
+      then !(matchHost s.not n h)
+      else if s.and != []
+      then lib.all (sub: matchHost sub n h) s.and
+      else
+        s.all
+        || (s.hosts != [] && builtins.elem n s.hosts)
+        || (s.channel != null && h.channel == s.channel)
+        || (s.tags != [] && lib.all (t: builtins.elem t h.tags) s.tags)
+        || (s.tagsAny != [] && lib.any (t: builtins.elem t h.tags) s.tagsAny);
   in
-    builtins.filter matches names;
+    builtins.filter (n: matchHost sel n hosts.${n}) names;
 
   # --- Invariant checks (RFC-0001 §4.2) ---
   checkInvariants = cfg: let
@@ -426,8 +444,6 @@
         // {inherit signedAt ciCommit;}
         // lib.optionalAttrs (signatureAlgorithm != null) {inherit signatureAlgorithm;};
     };
-in {
-  inherit withSignature;
   mkFleet = input: let
     evaluated = lib.evalModules {
       modules = [
@@ -472,4 +488,49 @@ in {
     };
   in
     evaluated.config // {resolved = resolveFleet evaluated.config;};
+
+  # --- Composition (RFC-0001 §5) ---
+  # Merge a list of mkFleet-input attrsets into a single fleet value.
+  # Precedence rules:
+  #   - hosts / tags / channels: strict merge — same name across inputs throws.
+  #   - rolloutPolicies: later wins (associative, not commutative per RFC §5).
+  #   - edges / disruptionBudgets: concatenated (no dedup; order preserved).
+  #   - complianceFrameworks: union of whatever each input specified; if no
+  #     input declared any, the mkFleet default list applies.
+  mergeFleets = fleetInputs: let
+    mergeStrict = kind: a: b:
+      lib.foldl' (
+        acc: name:
+          if acc ? ${name}
+          then throw "mergeFleets: ${kind} '${name}' is defined in multiple inputs"
+          else acc // {${name} = b.${name};}
+      )
+      a (lib.attrNames b);
+    step = acc: input: {
+      hosts = mergeStrict "host" acc.hosts (input.hosts or {});
+      tags = mergeStrict "tag" acc.tags (input.tags or {});
+      channels = mergeStrict "channel" acc.channels (input.channels or {});
+      rolloutPolicies = acc.rolloutPolicies // (input.rolloutPolicies or {});
+      edges = acc.edges ++ (input.edges or []);
+      disruptionBudgets = acc.disruptionBudgets ++ (input.disruptionBudgets or []);
+    };
+    empty = {
+      hosts = {};
+      tags = {};
+      channels = {};
+      rolloutPolicies = {};
+      edges = [];
+      disruptionBudgets = [];
+    };
+    merged = lib.foldl' step empty fleetInputs;
+    specifiedFrameworks = lib.concatMap (i: i.complianceFrameworks or []) fleetInputs;
+  in
+    mkFleet (
+      merged
+      // lib.optionalAttrs (specifiedFrameworks != []) {
+        complianceFrameworks = lib.unique specifiedFrameworks;
+      }
+    );
+in {
+  inherit mkFleet mergeFleets withSignature;
 }

--- a/modules/_shared/lib/default.nix
+++ b/modules/_shared/lib/default.nix
@@ -7,5 +7,5 @@
 in {
   mkHost = import ./mk-host.nix {inherit inputs lib;};
   mkVmApps = import ./mk-vm-apps.nix {inherit inputs;};
-  inherit (mkFleetImpl) mkFleet withSignature;
+  inherit (mkFleetImpl) mkFleet mergeFleets withSignature;
 }

--- a/tests/lib/mkFleet/default.nix
+++ b/tests/lib/mkFleet/default.nix
@@ -5,10 +5,13 @@
 # Each .nix file under ./negative/ is expected to `throw` a specific error.
 {
   lib,
-  mkFleet ? (import ../../../lib/mkFleet.nix {inherit lib;}).mkFleet,
+  impl ? import ../../../lib/mkFleet.nix {inherit lib;},
 }: let
+  inherit (impl) mkFleet mergeFleets;
+  fixtureArgs = {inherit lib mkFleet mergeFleets;};
+
   runPositive = path: let
-    cfg = import path {inherit lib mkFleet;};
+    cfg = import path fixtureArgs;
     expectedPath = lib.replaceStrings [".nix"] [".resolved.json"] (toString path);
     expected = builtins.fromJSON (builtins.readFile expectedPath);
     actual = cfg.resolved;
@@ -24,7 +27,7 @@
       '';
 
   runNegative = path: let
-    result = builtins.tryEval (import path {inherit lib mkFleet;}).resolved;
+    result = builtins.tryEval (import path fixtureArgs).resolved;
   in
     if result.success
     then throw "expected eval failure for ${toString path}, got success"

--- a/tests/lib/mkFleet/fixtures/homelab.resolved.json
+++ b/tests/lib/mkFleet/fixtures/homelab.resolved.json
@@ -75,8 +75,10 @@
         {
           "selector": {
             "all": true,
+            "and": [],
             "channel": null,
             "hosts": [],
+            "not": null,
             "tags": [],
             "tagsAny": []
           },
@@ -96,8 +98,10 @@
         {
           "selector": {
             "all": false,
+            "and": [],
             "channel": null,
             "hosts": [],
+            "not": null,
             "tags": ["workstation"],
             "tagsAny": []
           },
@@ -106,8 +110,10 @@
         {
           "selector": {
             "all": false,
+            "and": [],
             "channel": null,
             "hosts": [],
+            "not": null,
             "tags": ["always-on"],
             "tagsAny": []
           },

--- a/tests/lib/mkFleet/fixtures/merge-fleets.nix
+++ b/tests/lib/mkFleet/fixtures/merge-fleets.nix
@@ -1,0 +1,61 @@
+# tests/lib/mkFleet/fixtures/merge-fleets.nix
+#
+# Exercises RFC-0001 §5 composition via mergeFleets.
+# Two fleet inputs (paris, lyon) with disjoint hosts + tags + channels.
+# Both share a single rolloutPolicy name; per RFC the later input wins
+# (associative, not commutative) — here they define the same policy so the
+# winner is indistinguishable.
+# Edges and disruptionBudgets from both inputs concatenate.
+{mergeFleets, ...}: let
+  stub = import ./_stub-configuration.nix {};
+  paris = {
+    hosts.paris-1 = {
+      system = "x86_64-linux";
+      configuration = stub;
+      tags = ["paris" "eu-fr"];
+      channel = "stable";
+    };
+    tags.paris.description = "Paris datacenter.";
+    channels.stable = {
+      rolloutPolicy = "all";
+      signingIntervalMinutes = 60;
+      freshnessWindow = 180;
+    };
+    rolloutPolicies.all = {
+      strategy = "all-at-once";
+      waves = [
+        {
+          selector.all = true;
+          soakMinutes = 0;
+        }
+      ];
+    };
+    disruptionBudgets = [
+      {
+        selector.tags = ["paris"];
+        maxInFlight = 1;
+      }
+    ];
+  };
+  lyon = {
+    hosts.lyon-1 = {
+      system = "x86_64-linux";
+      configuration = stub;
+      tags = ["lyon" "eu-fr"];
+      channel = "edge";
+    };
+    tags.lyon.description = "Lyon datacenter.";
+    channels.edge = {
+      rolloutPolicy = "all";
+      signingIntervalMinutes = 60;
+      freshnessWindow = 240;
+    };
+    disruptionBudgets = [
+      {
+        selector.tags = ["lyon"];
+        maxInFlight = 1;
+      }
+    ];
+  };
+in
+  mergeFleets [paris lyon]

--- a/tests/lib/mkFleet/fixtures/merge-fleets.resolved.json
+++ b/tests/lib/mkFleet/fixtures/merge-fleets.resolved.json
@@ -1,5 +1,15 @@
 {
   "channels": {
+    "edge": {
+      "compliance": {
+        "frameworks": [],
+        "strict": true
+      },
+      "freshnessWindow": 240,
+      "reconcileIntervalMinutes": 30,
+      "rolloutPolicy": "all",
+      "signingIntervalMinutes": 60
+    },
     "stable": {
       "compliance": {
         "frameworks": [],
@@ -7,19 +17,37 @@
       },
       "freshnessWindow": 180,
       "reconcileIntervalMinutes": 30,
-      "rolloutPolicy": "emptyish",
+      "rolloutPolicy": "all",
       "signingIntervalMinutes": 60
     }
   },
-  "disruptionBudgets": [],
+  "disruptionBudgets": [
+    {
+      "hosts": ["paris-1"],
+      "maxInFlight": 1,
+      "maxInFlightPct": null
+    },
+    {
+      "hosts": ["lyon-1"],
+      "maxInFlight": 1,
+      "maxInFlightPct": null
+    }
+  ],
   "edges": [],
   "hosts": {
-    "m": {
+    "lyon-1": {
+      "channel": "edge",
+      "closureHash": null,
+      "pubkey": null,
+      "system": "x86_64-linux",
+      "tags": ["lyon", "eu-fr"]
+    },
+    "paris-1": {
       "channel": "stable",
       "closureHash": null,
       "pubkey": null,
       "system": "x86_64-linux",
-      "tags": ["role-a"]
+      "tags": ["paris", "eu-fr"]
     }
   },
   "meta": {
@@ -28,23 +56,11 @@
     "signedAt": null
   },
   "rolloutPolicies": {
-    "emptyish": {
+    "all": {
       "healthGate": {},
       "onHealthFailure": "rollback-and-halt",
-      "strategy": "canary",
+      "strategy": "all-at-once",
       "waves": [
-        {
-          "selector": {
-            "all": false,
-            "and": [],
-            "channel": null,
-            "hosts": [],
-            "not": null,
-            "tags": ["role-b"],
-            "tagsAny": []
-          },
-          "soakMinutes": 10
-        },
         {
           "selector": {
             "all": true,
@@ -62,13 +78,15 @@
   },
   "schemaVersion": 1,
   "waves": {
+    "edge": [
+      {
+        "hosts": ["lyon-1", "paris-1"],
+        "soakMinutes": 0
+      }
+    ],
     "stable": [
       {
-        "hosts": [],
-        "soakMinutes": 10
-      },
-      {
-        "hosts": ["m"],
+        "hosts": ["lyon-1", "paris-1"],
         "soakMinutes": 0
       }
     ]

--- a/tests/lib/mkFleet/fixtures/selector-and.nix
+++ b/tests/lib/mkFleet/fixtures/selector-and.nix
@@ -1,0 +1,54 @@
+# tests/lib/mkFleet/fixtures/selector-and.nix
+#
+# Exercises RFC-0001 §3 selector intersection (`and`).
+# Fleet: four hosts with mixed tags. The wave selector
+# { and = [ { tags = ["eu-fr"]; } { tags = ["server"]; } ]; } must
+# resolve to hosts that carry BOTH tags.
+{mkFleet, ...}: let
+  stub = import ./_stub-configuration.nix {};
+in
+  mkFleet {
+    hosts = {
+      eu-server = {
+        system = "x86_64-linux";
+        configuration = stub;
+        tags = ["eu-fr" "server"];
+        channel = "stable";
+      };
+      eu-workstation = {
+        system = "x86_64-linux";
+        configuration = stub;
+        tags = ["eu-fr" "workstation"];
+        channel = "stable";
+      };
+      us-server = {
+        system = "x86_64-linux";
+        configuration = stub;
+        tags = ["us-east" "server"];
+        channel = "stable";
+      };
+      sensor = {
+        system = "aarch64-linux";
+        configuration = stub;
+        tags = ["eu-fr" "sensor"];
+        channel = "stable";
+      };
+    };
+    channels.stable = {
+      rolloutPolicy = "eu-servers-only";
+      signingIntervalMinutes = 60;
+      freshnessWindow = 180;
+    };
+    rolloutPolicies.eu-servers-only = {
+      strategy = "all-at-once";
+      waves = [
+        {
+          selector.and = [
+            {tags = ["eu-fr"];}
+            {tags = ["server"];}
+          ];
+          soakMinutes = 0;
+        }
+      ];
+    };
+  }

--- a/tests/lib/mkFleet/fixtures/selector-and.resolved.json
+++ b/tests/lib/mkFleet/fixtures/selector-and.resolved.json
@@ -1,0 +1,100 @@
+{
+  "channels": {
+    "stable": {
+      "compliance": {
+        "frameworks": [],
+        "strict": true
+      },
+      "freshnessWindow": 180,
+      "reconcileIntervalMinutes": 30,
+      "rolloutPolicy": "eu-servers-only",
+      "signingIntervalMinutes": 60
+    }
+  },
+  "disruptionBudgets": [],
+  "edges": [],
+  "hosts": {
+    "eu-server": {
+      "channel": "stable",
+      "closureHash": null,
+      "pubkey": null,
+      "system": "x86_64-linux",
+      "tags": ["eu-fr", "server"]
+    },
+    "eu-workstation": {
+      "channel": "stable",
+      "closureHash": null,
+      "pubkey": null,
+      "system": "x86_64-linux",
+      "tags": ["eu-fr", "workstation"]
+    },
+    "sensor": {
+      "channel": "stable",
+      "closureHash": null,
+      "pubkey": null,
+      "system": "aarch64-linux",
+      "tags": ["eu-fr", "sensor"]
+    },
+    "us-server": {
+      "channel": "stable",
+      "closureHash": null,
+      "pubkey": null,
+      "system": "x86_64-linux",
+      "tags": ["us-east", "server"]
+    }
+  },
+  "meta": {
+    "ciCommit": null,
+    "schemaVersion": 1,
+    "signedAt": null
+  },
+  "rolloutPolicies": {
+    "eu-servers-only": {
+      "healthGate": {},
+      "onHealthFailure": "rollback-and-halt",
+      "strategy": "all-at-once",
+      "waves": [
+        {
+          "selector": {
+            "all": false,
+            "and": [
+              {
+                "all": false,
+                "and": [],
+                "channel": null,
+                "hosts": [],
+                "not": null,
+                "tags": ["eu-fr"],
+                "tagsAny": []
+              },
+              {
+                "all": false,
+                "and": [],
+                "channel": null,
+                "hosts": [],
+                "not": null,
+                "tags": ["server"],
+                "tagsAny": []
+              }
+            ],
+            "channel": null,
+            "hosts": [],
+            "not": null,
+            "tags": [],
+            "tagsAny": []
+          },
+          "soakMinutes": 0
+        }
+      ]
+    }
+  },
+  "schemaVersion": 1,
+  "waves": {
+    "stable": [
+      {
+        "hosts": ["eu-server"],
+        "soakMinutes": 0
+      }
+    ]
+  }
+}

--- a/tests/lib/mkFleet/fixtures/selector-not.nix
+++ b/tests/lib/mkFleet/fixtures/selector-not.nix
@@ -1,0 +1,45 @@
+# tests/lib/mkFleet/fixtures/selector-not.nix
+#
+# Exercises RFC-0001 §3 selector negation (`not`).
+# Fleet: three hosts, one tagged "deprecated". The wave selector
+# { not = { tags = ["deprecated"]; }; } must resolve to the two
+# non-deprecated hosts only.
+{mkFleet, ...}: let
+  stub = import ./_stub-configuration.nix {};
+in
+  mkFleet {
+    hosts = {
+      a = {
+        system = "x86_64-linux";
+        configuration = stub;
+        tags = ["web"];
+        channel = "stable";
+      };
+      b = {
+        system = "x86_64-linux";
+        configuration = stub;
+        tags = ["web" "deprecated"];
+        channel = "stable";
+      };
+      c = {
+        system = "x86_64-linux";
+        configuration = stub;
+        tags = ["web"];
+        channel = "stable";
+      };
+    };
+    channels.stable = {
+      rolloutPolicy = "skip-deprecated";
+      signingIntervalMinutes = 60;
+      freshnessWindow = 180;
+    };
+    rolloutPolicies.skip-deprecated = {
+      strategy = "all-at-once";
+      waves = [
+        {
+          selector.not = {tags = ["deprecated"];};
+          soakMinutes = 0;
+        }
+      ];
+    };
+  }

--- a/tests/lib/mkFleet/fixtures/selector-not.resolved.json
+++ b/tests/lib/mkFleet/fixtures/selector-not.resolved.json
@@ -7,19 +7,33 @@
       },
       "freshnessWindow": 180,
       "reconcileIntervalMinutes": 30,
-      "rolloutPolicy": "emptyish",
+      "rolloutPolicy": "skip-deprecated",
       "signingIntervalMinutes": 60
     }
   },
   "disruptionBudgets": [],
   "edges": [],
   "hosts": {
-    "m": {
+    "a": {
       "channel": "stable",
       "closureHash": null,
       "pubkey": null,
       "system": "x86_64-linux",
-      "tags": ["role-a"]
+      "tags": ["web"]
+    },
+    "b": {
+      "channel": "stable",
+      "closureHash": null,
+      "pubkey": null,
+      "system": "x86_64-linux",
+      "tags": ["web", "deprecated"]
+    },
+    "c": {
+      "channel": "stable",
+      "closureHash": null,
+      "pubkey": null,
+      "system": "x86_64-linux",
+      "tags": ["web"]
     }
   },
   "meta": {
@@ -28,10 +42,10 @@
     "signedAt": null
   },
   "rolloutPolicies": {
-    "emptyish": {
+    "skip-deprecated": {
       "healthGate": {},
       "onHealthFailure": "rollback-and-halt",
-      "strategy": "canary",
+      "strategy": "all-at-once",
       "waves": [
         {
           "selector": {
@@ -39,19 +53,15 @@
             "and": [],
             "channel": null,
             "hosts": [],
-            "not": null,
-            "tags": ["role-b"],
-            "tagsAny": []
-          },
-          "soakMinutes": 10
-        },
-        {
-          "selector": {
-            "all": true,
-            "and": [],
-            "channel": null,
-            "hosts": [],
-            "not": null,
+            "not": {
+              "all": false,
+              "and": [],
+              "channel": null,
+              "hosts": [],
+              "not": null,
+              "tags": ["deprecated"],
+              "tagsAny": []
+            },
             "tags": [],
             "tagsAny": []
           },
@@ -64,11 +74,7 @@
   "waves": {
     "stable": [
       {
-        "hosts": [],
-        "soakMinutes": 10
-      },
-      {
-        "hosts": ["m"],
+        "hosts": ["a", "c"],
         "soakMinutes": 0
       }
     ]

--- a/tests/lib/mkFleet/fixtures/tight-budget-warns.resolved.json
+++ b/tests/lib/mkFleet/fixtures/tight-budget-warns.resolved.json
@@ -116,8 +116,10 @@
         {
           "selector": {
             "all": true,
+            "and": [],
             "channel": null,
             "hosts": [],
+            "not": null,
             "tags": [],
             "tagsAny": []
           },

--- a/tests/lib/mkFleet/negative/merge-channel-conflict.nix
+++ b/tests/lib/mkFleet/negative/merge-channel-conflict.nix
@@ -1,0 +1,32 @@
+# Two fleet inputs declaring the same channel name: mergeFleets must throw.
+# Channels are strict-merged (unlike rolloutPolicies, which follow later-wins
+# per RFC-0001 §5).
+{mergeFleets, ...}: let
+  stub = import ../fixtures/_stub-configuration.nix {};
+  fleetWithChannel = hostName: freshness: {
+    hosts.${hostName} = {
+      system = "x86_64-linux";
+      configuration = stub;
+      tags = [];
+      channel = "stable";
+    };
+    channels.stable = {
+      rolloutPolicy = "all";
+      signingIntervalMinutes = 60;
+      freshnessWindow = freshness;
+    };
+    rolloutPolicies.all = {
+      strategy = "all-at-once";
+      waves = [
+        {
+          selector.all = true;
+          soakMinutes = 0;
+        }
+      ];
+    };
+  };
+in
+  mergeFleets [
+    (fleetWithChannel "a" 180)
+    (fleetWithChannel "b" 240)
+  ]

--- a/tests/lib/mkFleet/negative/merge-host-conflict.nix
+++ b/tests/lib/mkFleet/negative/merge-host-conflict.nix
@@ -1,0 +1,31 @@
+# Two fleet inputs declaring the same host name: mergeFleets must throw
+# per RFC-0001 §5 "same host name fails eval".
+{mergeFleets, ...}: let
+  stub = import ../fixtures/_stub-configuration.nix {};
+  shared = hostTags: {
+    hosts.duplicated = {
+      system = "x86_64-linux";
+      configuration = stub;
+      tags = hostTags;
+      channel = "stable";
+    };
+    channels.stable = {
+      rolloutPolicy = "all";
+      signingIntervalMinutes = 60;
+      freshnessWindow = 180;
+    };
+    rolloutPolicies.all = {
+      strategy = "all-at-once";
+      waves = [
+        {
+          selector.all = true;
+          soakMinutes = 0;
+        }
+      ];
+    };
+  };
+in
+  mergeFleets [
+    (shared ["a"])
+    (shared ["b"])
+  ]


### PR DESCRIPTION
Closes the remaining RFC-0001 §3 and §5 gaps surfaced by the audit: selector.not and selector.and, plus mergeFleets for composing multiple fleet declarations. 12 mkFleet fixtures green; nix flake check clean. Self-contained, does not touch v0.2/v1 agent work.