### PR TITLE
Phase 2: read-only reconciler runner (M70q timer)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,18 +3,6 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,54 +77,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arc-swap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
-name = "asn1-rs"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
-dependencies = [
- "asn1-rs-derive",
- "asn1-rs-impl",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "asn1-rs-impl"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,17 +102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,102 +112,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "aws-lc-rs"
-version = "1.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
-name = "axum"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
-dependencies = [
- "axum-core",
- "bytes",
- "form_urlencoded",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde_core",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-server"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
-dependencies = [
- "arc-swap",
- "bytes",
- "fs-err",
- "http",
- "http-body",
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "rustls",
- "rustls-pemfile",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower-service",
-]
 
 [[package]]
 name = "base16ct"
@@ -343,8 +176,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -413,15 +244,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "colorchoice"
@@ -544,12 +366,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
-
-[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,29 +392,6 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
-]
-
-[[package]]
-name = "der-parser"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
-dependencies = [
- "asn1-rs",
- "displaydoc",
- "nom",
- "num-bigint",
- "num-traits",
- "rusticata-macros",
-]
-
-[[package]]
-name = "deranged"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
 ]
 
 [[package]]
@@ -638,12 +431,6 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ecdsa"
@@ -720,18 +507,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,22 +557,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs-err"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
-dependencies = [
- "autocfg",
- "tokio",
-]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -957,27 +716,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
-
-[[package]]
-name = "hashlink"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
-dependencies = [
- "hashbrown 0.14.5",
-]
 
 [[package]]
 name = "heck"
@@ -990,12 +731,6 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
@@ -1247,7 +982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1279,16 +1014,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,17 +1036,6 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
-
-[[package]]
-name = "libsqlite3-sys"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1372,28 +1086,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchit"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -1419,7 +1115,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1450,7 +1146,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1462,32 +1158,14 @@ name = "nixfleet-control-plane"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "axum",
- "axum-server",
  "chrono",
  "clap",
- "hex",
- "http",
  "nixfleet-proto",
  "nixfleet-reconciler",
- "rcgen",
- "refinery",
- "reqwest",
- "rusqlite",
- "rustls",
- "rustls-pki-types",
- "serde",
  "serde_json",
- "sha2",
  "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-service",
  "tracing",
  "tracing-subscriber",
- "x509-parser",
 ]
 
 [[package]]
@@ -1515,7 +1193,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1527,16 +1205,6 @@ dependencies = [
  "nixfleet-proto",
  "nixfleet-reconciler",
  "serde_json",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -1552,31 +1220,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-conv"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -1596,15 +1239,6 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
-]
-
-[[package]]
-name = "oid-registry"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
-dependencies = [
- "asn1-rs",
 ]
 
 [[package]]
@@ -1661,16 +1295,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem"
-version = "3.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
-dependencies = [
- "base64",
- "serde_core",
-]
-
-[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,12 +1326,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1715,12 +1333,6 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1793,7 +1405,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -1814,7 +1426,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1888,69 +1500,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rcgen"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
-dependencies = [
- "pem",
- "ring",
- "rustls-pki-types",
- "time",
- "yasna",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "refinery"
-version = "0.8.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba5d693abf62492c37268512ff35b77655d2e957ca53dab85bf993fe9172d15"
-dependencies = [
- "refinery-core",
- "refinery-macros",
-]
-
-[[package]]
-name = "refinery-core"
-version = "0.8.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a83581f18c1a4c3a6ebd7a174bdc665f17f618d79f7edccb6a0ac67e660b319"
-dependencies = [
- "async-trait",
- "cfg-if",
- "log",
- "regex",
- "rusqlite",
- "serde",
- "siphasher",
- "thiserror 1.0.69",
- "time",
- "toml",
- "url",
- "walkdir",
-]
-
-[[package]]
-name = "refinery-macros"
-version = "0.8.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c225407d8e52ef8cf094393781ecda9a99d6544ec28d90a6915751de259264"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "refinery-core",
- "regex",
- "syn",
 ]
 
 [[package]]
@@ -2046,20 +1601,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusqlite"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
-dependencies = [
- "bitflags",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink",
- "libsqlite3-sys",
- "smallvec",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2072,15 +1613,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rusticata-macros"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
-dependencies = [
- "nom",
 ]
 
 [[package]]
@@ -2102,8 +1634,6 @@ version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
- "aws-lc-rs",
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2125,15 +1655,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,7 +1670,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2172,15 +1692,6 @@ name = "ryu-js"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "schannel"
@@ -2295,26 +1806,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
-dependencies = [
- "itoa",
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2371,12 +1862,6 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "siphasher"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
@@ -2480,31 +1965,11 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2525,37 +1990,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "time"
-version = "0.3.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
-dependencies = [
- "deranged",
- "itoa",
- "num-conv",
- "powerfmt",
- "serde_core",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
-name = "time-macros"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
-dependencies = [
- "num-conv",
- "time-core",
 ]
 
 [[package]]
@@ -2635,47 +2069,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_write",
- "winnow",
-]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
-
-[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2688,7 +2081,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -2727,7 +2119,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2863,12 +2254,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2881,16 +2266,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
 ]
 
 [[package]]
@@ -3016,15 +2391,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -3248,15 +2614,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "wiremock"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3290,32 +2647,6 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "x509-parser"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
-dependencies = [
- "asn1-rs",
- "data-encoding",
- "der-parser",
- "lazy_static",
- "nom",
- "oid-registry",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "yasna"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
-dependencies = [
- "time",
-]
 
 [[package]]
 name = "yoke"

--- a/crates/nixfleet-control-plane/Cargo.toml
+++ b/crates/nixfleet-control-plane/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nixfleet-control-plane"
 version = "0.2.0"
 edition = "2021"
-description = "NixFleet v0.2 control plane skeleton (Axum + SQLite + mTLS)"
+description = "NixFleet control plane — Phase 2: read-only reconciler runner"
 license = "AGPL-3.0-only"
 repository = "https://github.com/arcanesys/nixfleet"
 homepage = "https://github.com/arcanesys/nixfleet"
@@ -16,33 +16,17 @@ path = "src/lib.rs"
 name = "nixfleet-control-plane"
 path = "src/main.rs"
 
+# Phase 2 deps only. Phase 3+ adds axum, tokio, rusqlite, rustls when
+# the wire endpoints land — re-add per phase, not speculatively.
 [dependencies]
 nixfleet-proto = { path = "../nixfleet-proto" }
 nixfleet-reconciler = { path = "../nixfleet-reconciler" }
-axum = "0.8"
-axum-server = { version = "0.7", features = ["tls-rustls"] }
-tokio = { version = "1", features = ["full"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-clap = { version = "4", features = ["derive", "env"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
-rusqlite = { version = "0.32", features = ["bundled"] }
-refinery = { version = "0.8", features = ["rusqlite"] }
 chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "4", features = ["derive"] }
+serde_json = "1"
 anyhow = "1"
-thiserror = "2"
-rustls = "0.23"
-tokio-rustls = "0.26"
-x509-parser = "0.16"
-tower-service = "0.3"
-rustls-pki-types = "1"
-http = "1"
-sha2 = "0.10"
-hex = "0.4"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 [dev-dependencies]
 tempfile = "3"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
-rcgen = "0.13"
-tower = { version = "0.5", features = ["util"] }

--- a/crates/nixfleet-control-plane/fixtures/observed/empty.json
+++ b/crates/nixfleet-control-plane/fixtures/observed/empty.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Phase 2 demo fixture — empty observed state. No channel refs known yet, no rollouts in flight, no host check-ins. The reconciler should emit zero actions because there is nothing to reconcile against. Useful as a starting point for the operator to copy and edit.",
+  "channelRefs": {},
+  "lastRolledRefs": {},
+  "hostState": {},
+  "activeRollouts": []
+}

--- a/crates/nixfleet-control-plane/fixtures/observed/fresh-rollout.json
+++ b/crates/nixfleet-control-plane/fixtures/observed/fresh-rollout.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "Phase 2 demo fixture — channel ref has moved (CI committed a new fleet.resolved) but no rollout has been opened yet. Reconciler should emit one OpenRollout action for the channel. The operator hand-edits channelRefs after every CI release until Phase 3 wires the live SQLite projection.",
+  "channelRefs": {
+    "stable": "abc123def456-replace-me-with-real-git-rev"
+  },
+  "lastRolledRefs": {},
+  "hostState": {
+    "lab":   { "online": true, "currentGeneration": null },
+    "krach": { "online": true, "currentGeneration": null },
+    "ohm":   { "online": true, "currentGeneration": null },
+    "aether":{ "online": true, "currentGeneration": null },
+    "pixel": { "online": true, "currentGeneration": null }
+  },
+  "activeRollouts": []
+}

--- a/crates/nixfleet-control-plane/fixtures/observed/in-progress.json
+++ b/crates/nixfleet-control-plane/fixtures/observed/in-progress.json
@@ -1,0 +1,32 @@
+{
+  "_comment": "Phase 2 demo fixture — a rollout is already in flight. Some hosts are Queued (haven't been dispatched yet); the reconciler should advance them to Dispatched if disruption budgets and edge predecessors permit. Useful for watching the per-host advance logic in the journal.",
+  "channelRefs": {
+    "stable": "abc123def456"
+  },
+  "lastRolledRefs": {
+    "stable": "old000000-pre-rollout-ref"
+  },
+  "hostState": {
+    "lab":   { "online": true, "currentGeneration": "sha256-old-closure" },
+    "krach": { "online": true, "currentGeneration": "sha256-old-closure" },
+    "ohm":   { "online": true, "currentGeneration": "sha256-old-closure" },
+    "aether":{ "online": true, "currentGeneration": "sha256-old-closure" },
+    "pixel": { "online": true, "currentGeneration": "sha256-old-closure" }
+  },
+  "activeRollouts": [
+    {
+      "id": "stable@abc123",
+      "channel": "stable",
+      "targetRef": "abc123def456",
+      "state": "Executing",
+      "currentWave": 0,
+      "hostStates": {
+        "lab":   "Queued",
+        "krach": "Queued",
+        "ohm":   "Queued",
+        "aether":"Queued",
+        "pixel": "Queued"
+      }
+    }
+  ]
+}

--- a/crates/nixfleet-control-plane/src/lib.rs
+++ b/crates/nixfleet-control-plane/src/lib.rs
@@ -1,10 +1,251 @@
-//! NixFleet v0.2 control plane library.
+//! NixFleet control plane — Phase 2 (read-only reconciler runner).
 //!
-//! v0.2 is an Axum + SQLite + mTLS skeleton serving the four wire
-//! endpoints from RFC-0003 §4. It reads trust from a JSON file
-//! (`docs/trust-root-flow.md §3.2`), polls a local `fleet.resolved.json`
-//! path, calls `nixfleet_reconciler::verify_artifact` on every load,
-//! refuses unverified artifacts, and logs reconcile actions per tick.
+//! Per the architecture doc Phase 2: ship the reconciler from the spike,
+//! run it as a systemd timer on the M70q, read `fleet.resolved.json` +
+//! a simulated `observed.json`, print the action plan to the journal.
+//! No actions taken, no agents yet — just planning.
 //!
-//! Every SQLite column carries a `-- derivable from: …` comment per
-//! `docs/CONTRACTS.md §IV` (storage purity rule).
+//! This crate exposes [`tick`] as a pure function (testable) and
+//! [`render_plan`] as a JSON-line emitter for the systemd journal. The
+//! binary in `src/main.rs` is the thin CLI shell.
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use nixfleet_proto::TrustConfig;
+use nixfleet_reconciler::{reconcile, verify_artifact, Action, Observed, VerifyError};
+use serde_json::json;
+
+#[derive(Debug, Clone)]
+pub struct TickInputs {
+    pub artifact_path: PathBuf,
+    pub signature_path: PathBuf,
+    pub trust_path: PathBuf,
+    pub observed_path: PathBuf,
+    pub now: DateTime<Utc>,
+    pub freshness_window: Duration,
+}
+
+#[derive(Debug)]
+pub struct TickOutput {
+    pub now: DateTime<Utc>,
+    pub verify: VerifyOutcome,
+}
+
+#[derive(Debug)]
+pub enum VerifyOutcome {
+    Ok {
+        signed_at: DateTime<Utc>,
+        ci_commit: Option<String>,
+        observed: Observed,
+        actions: Vec<Action>,
+    },
+    Failed {
+        reason: String,
+    },
+}
+
+pub fn tick(inputs: &TickInputs) -> anyhow::Result<TickOutput> {
+    let artifact = fs::read(&inputs.artifact_path)
+        .map_err(|e| anyhow::anyhow!("read artifact {}: {e}", inputs.artifact_path.display()))?;
+    let signature = fs::read(&inputs.signature_path)
+        .map_err(|e| anyhow::anyhow!("read signature {}: {e}", inputs.signature_path.display()))?;
+    let trust_raw = fs::read_to_string(&inputs.trust_path)
+        .map_err(|e| anyhow::anyhow!("read trust {}: {e}", inputs.trust_path.display()))?;
+    let trust: TrustConfig = serde_json::from_str(&trust_raw)
+        .map_err(|e| anyhow::anyhow!("parse trust {}: {e}", inputs.trust_path.display()))?;
+
+    let trusted_keys = trust.ci_release_key.active_keys();
+    let reject_before = trust.ci_release_key.reject_before;
+
+    let verify = match verify_artifact(
+        &artifact,
+        &signature,
+        &trusted_keys,
+        inputs.now,
+        inputs.freshness_window,
+        reject_before,
+    ) {
+        Ok(fleet) => {
+            let signed_at = fleet
+                .meta
+                .signed_at
+                .expect("verified artifact carries meta.signedAt by §4 contract");
+            let ci_commit = fleet.meta.ci_commit.clone();
+
+            let observed_raw = fs::read_to_string(&inputs.observed_path).map_err(|e| {
+                anyhow::anyhow!("read observed {}: {e}", inputs.observed_path.display())
+            })?;
+            let observed: Observed = serde_json::from_str(&observed_raw).map_err(|e| {
+                anyhow::anyhow!("parse observed {}: {e}", inputs.observed_path.display())
+            })?;
+
+            let actions = reconcile(&fleet, &observed, inputs.now);
+
+            VerifyOutcome::Ok {
+                signed_at,
+                ci_commit,
+                observed,
+                actions,
+            }
+        }
+        Err(err) => VerifyOutcome::Failed {
+            reason: classify_verify_error(&err),
+        },
+    };
+
+    Ok(TickOutput {
+        now: inputs.now,
+        verify,
+    })
+}
+
+fn classify_verify_error(err: &VerifyError) -> String {
+    match err {
+        VerifyError::Parse(_) => "parse".into(),
+        VerifyError::BadSignature => "bad-signature".into(),
+        VerifyError::NotSigned => "unsigned".into(),
+        VerifyError::Stale { .. } => "stale".into(),
+        VerifyError::RejectedBeforeTimestamp { .. } => "reject-before".into(),
+        VerifyError::SchemaVersionUnsupported(_) => "schema-version".into(),
+        VerifyError::Canonicalize(_) => "canonicalize".into(),
+        VerifyError::UnsupportedAlgorithm { .. } => "unsupported-algorithm".into(),
+        VerifyError::BadPubkeyEncoding { .. } => "bad-pubkey".into(),
+        VerifyError::NoTrustRoots => "no-trust-roots".into(),
+    }
+}
+
+/// Render a tick result as one summary JSON line plus one JSON line per
+/// action. Each line is intended for the systemd journal — `journalctl
+/// -o cat` produces the raw JSON; `jq` filters trivially.
+pub fn render_plan(out: &TickOutput) -> String {
+    let mut s = String::new();
+    s.push_str(&render_summary(out));
+    s.push('\n');
+    if let VerifyOutcome::Ok { actions, .. } = &out.verify {
+        for action in actions {
+            s.push_str(&serde_json::to_string(action).expect("Action serialises"));
+            s.push('\n');
+        }
+    }
+    s
+}
+
+fn render_summary(out: &TickOutput) -> String {
+    match &out.verify {
+        VerifyOutcome::Ok {
+            signed_at,
+            ci_commit,
+            observed,
+            actions,
+        } => json!({
+            "event": "tick",
+            "verify_ok": true,
+            "now": out.now.to_rfc3339(),
+            "signed_at": signed_at.to_rfc3339(),
+            "ci_commit": ci_commit,
+            "channels_observed": observed.channel_refs.len(),
+            "active_rollouts": observed.active_rollouts.len(),
+            "actions": actions.len(),
+        })
+        .to_string(),
+        VerifyOutcome::Failed { reason } => json!({
+            "event": "tick",
+            "verify_ok": false,
+            "now": out.now.to_rfc3339(),
+            "reason": reason,
+        })
+        .to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn observed_no_rollouts() -> Observed {
+        Observed {
+            channel_refs: HashMap::from([("stable".to_string(), "abc123".to_string())]),
+            last_rolled_refs: HashMap::new(),
+            host_state: HashMap::new(),
+            active_rollouts: vec![],
+        }
+    }
+
+    #[test]
+    fn render_summary_verify_ok_shape() {
+        let out = TickOutput {
+            now: DateTime::parse_from_rfc3339("2026-04-25T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            verify: VerifyOutcome::Ok {
+                signed_at: DateTime::parse_from_rfc3339("2026-04-25T00:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+                ci_commit: Some("deadbeef".into()),
+                observed: observed_no_rollouts(),
+                actions: vec![Action::OpenRollout {
+                    channel: "stable".into(),
+                    target_ref: "abc123".into(),
+                }],
+            },
+        };
+        let summary = render_summary(&out);
+        let v: serde_json::Value = serde_json::from_str(&summary).unwrap();
+        assert_eq!(v["event"], "tick");
+        assert_eq!(v["verify_ok"], true);
+        assert_eq!(v["actions"], 1);
+        assert_eq!(v["ci_commit"], "deadbeef");
+    }
+
+    #[test]
+    fn render_summary_verify_failed_shape() {
+        let out = TickOutput {
+            now: Utc::now(),
+            verify: VerifyOutcome::Failed {
+                reason: "stale".into(),
+            },
+        };
+        let summary = render_summary(&out);
+        let v: serde_json::Value = serde_json::from_str(&summary).unwrap();
+        assert_eq!(v["verify_ok"], false);
+        assert_eq!(v["reason"], "stale");
+    }
+
+    #[test]
+    fn render_plan_emits_one_line_per_action_plus_summary() {
+        let out = TickOutput {
+            now: Utc::now(),
+            verify: VerifyOutcome::Ok {
+                signed_at: Utc::now(),
+                ci_commit: None,
+                observed: observed_no_rollouts(),
+                actions: vec![
+                    Action::OpenRollout {
+                        channel: "stable".into(),
+                        target_ref: "abc".into(),
+                    },
+                    Action::Skip {
+                        host: "krach".into(),
+                        reason: "offline".into(),
+                    },
+                ],
+            },
+        };
+        let body = render_plan(&out);
+        let lines: Vec<&str> = body.lines().collect();
+        assert_eq!(lines.len(), 3, "one summary + two actions");
+
+        let summary: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(summary["event"], "tick");
+
+        let action0: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(action0["action"], "open_rollout");
+
+        let action1: serde_json::Value = serde_json::from_str(lines[2]).unwrap();
+        assert_eq!(action1["action"], "skip");
+    }
+}

--- a/crates/nixfleet-control-plane/src/main.rs
+++ b/crates/nixfleet-control-plane/src/main.rs
@@ -1,7 +1,94 @@
-fn main() {
-    tracing_subscriber::fmt::init();
-    tracing::info!(
-        version = env!("CARGO_PKG_VERSION"),
-        "nixfleet-control-plane v0.2 skeleton — functional body lands in PR 2"
-    );
+//! `nixfleet-control-plane` — Phase 2 reconciler runner CLI.
+//!
+//! One-shot: read fleet.resolved + signature + trust + observed, verify,
+//! reconcile, print the action plan as JSON lines on stdout, exit.
+//! Intended to run from a systemd timer on the M70q (lab) so every tick
+//! lands as a journal entry the operator can grep / `jq` / alert on.
+//!
+//! Phase 3 will graft the agent endpoints (RFC-0003) into this binary
+//! and replace the file-backed `observed.json` with a live SQLite-backed
+//! projection. For Phase 2, observed.json is hand-written.
+//!
+//! Exit codes:
+//! - 0 — verify ok, plan emitted (the plan may be empty — no drift).
+//! - 1 — verify failed; one summary line emitted with the reason.
+//! - 2 — input/IO/parse error before verify could run.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+use std::time::Duration;
+
+use chrono::Utc;
+use clap::Parser;
+use nixfleet_control_plane::{render_plan, tick, TickInputs, VerifyOutcome};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "nixfleet-control-plane",
+    version,
+    about = "Phase 2 reconciler runner: verify fleet.resolved + reconcile against observed.json + emit plan."
+)]
+struct Args {
+    /// Path to releases/fleet.resolved.json (the bytes CI signed).
+    #[arg(long)]
+    artifact: PathBuf,
+
+    /// Path to releases/fleet.resolved.json.sig.
+    #[arg(long)]
+    signature: PathBuf,
+
+    /// Path to trust.json (shape per docs/trust-root-flow.md §3.4).
+    #[arg(long, default_value = "/etc/nixfleet/cp/trust.json")]
+    trust_file: PathBuf,
+
+    /// Path to a JSON file holding `Observed` state (channel refs,
+    /// host states, active rollouts). Phase 2 hand-writes this; Phase
+    /// 3 swaps to a SQLite projection.
+    #[arg(long)]
+    observed: PathBuf,
+
+    /// Maximum age (seconds) of meta.signedAt relative to now.
+    #[arg(long, default_value_t = 86400)]
+    freshness_window_secs: u64,
+}
+
+fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let args = Args::parse();
+
+    let inputs = TickInputs {
+        artifact_path: args.artifact,
+        signature_path: args.signature,
+        trust_path: args.trust_file,
+        observed_path: args.observed,
+        now: Utc::now(),
+        freshness_window: Duration::from_secs(args.freshness_window_secs),
+    };
+
+    let result = match tick(&inputs) {
+        Ok(r) => r,
+        Err(err) => {
+            eprintln!("tick: {err:#}");
+            return ExitCode::from(2);
+        }
+    };
+
+    print!("{}", render_plan(&result));
+
+    match &result.verify {
+        VerifyOutcome::Ok { actions, .. } => {
+            tracing::info!(actions = actions.len(), "tick ok");
+            ExitCode::SUCCESS
+        }
+        VerifyOutcome::Failed { reason } => {
+            tracing::warn!(%reason, "verify failed");
+            ExitCode::from(1)
+        }
+    }
 }

--- a/modules/scopes/nixfleet/_control-plane.nix
+++ b/modules/scopes/nixfleet/_control-plane.nix
@@ -1,11 +1,14 @@
-# NixOS service module for the NixFleet control plane server (v0.2).
+# NixOS service module for the NixFleet control plane (Phase 2: read-only
+# reconciler runner).
 #
-# Reads a trust-root declaration from /etc/nixfleet/cp/trust.json and
-# consumes a fleet.resolved.json artifact at a local path (git-pull
-# pattern, trust-root-flow.md §4 option b). Reload model is restart-only
-# (docs/trust-root-flow.md §7.1).
+# Phase 2 shape: one-shot binary launched on a systemd timer. Reads
+# fleet.resolved.json + signature + trust.json + observed.json, verifies,
+# reconciles, prints the action plan as JSON lines to the journal, exits.
+# No actions taken on the fleet — the reconciler brain runs against
+# simulated observed state until Phase 3 wires real agent check-ins.
 #
-# Auto-included by mkHost (disabled by default).
+# Auto-included by mkHost (disabled by default). Enable on the
+# coordinator host (typically the M70q) only.
 {
   config,
   inputs,
@@ -22,144 +25,130 @@
   trustJson = pkgs.writers.writeJSON "trust.json" trustConfig;
 in {
   options.services.nixfleet-control-plane = {
-    enable = lib.mkEnableOption "NixFleet control plane server";
+    enable = lib.mkEnableOption "NixFleet Phase 2 reconciler runner (read-only timer)";
 
-    listen = lib.mkOption {
+    artifactPath = lib.mkOption {
       type = lib.types.str;
-      default = "0.0.0.0:8080";
-      description = "Address and port to listen on.";
+      default = "/var/lib/nixfleet-cp/fleet/releases/fleet.resolved.json";
+      description = ''
+        Path to the canonical fleet.resolved.json bytes (the file CI
+        signed). Operator is responsible for keeping this path
+        up-to-date with the fleet repo's HEAD — typically a separate
+        timer that pulls the fleet repo into
+        `/var/lib/nixfleet-cp/fleet/`. The CP module does not pull
+        git itself.
+      '';
     };
 
-    dbPath = lib.mkOption {
+    signaturePath = lib.mkOption {
       type = lib.types.str;
-      default = "/var/lib/nixfleet-cp/state.db";
-      description = "Path to the SQLite state database.";
+      default = "/var/lib/nixfleet-cp/fleet/releases/fleet.resolved.json.sig";
+      description = "Path to the raw signature bytes paired with `artifactPath`.";
+    };
+
+    observedPath = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/nixfleet-cp/observed.json";
+      description = ''
+        Path to the JSON file holding observed fleet state (channel refs,
+        host states, active rollouts) — shape per
+        `nixfleet_reconciler::Observed`. In Phase 2 the operator
+        hand-writes this; Phase 3 swaps to a SQLite-backed projection
+        updated by agent check-ins. Examples in
+        `crates/nixfleet-control-plane/fixtures/observed/`.
+      '';
     };
 
     trustFile = lib.mkOption {
       type = lib.types.path;
       default = "/etc/nixfleet/cp/trust.json";
       description = ''
-        Path to the trust-root JSON file (see docs/trust-root-flow.md §3.4).
-        The default is materialised by this module from config.nixfleet.trust
-        via environment.etc.
+        Path to the trust-root JSON file (see
+        docs/trust-root-flow.md §3.4). Materialised by this module
+        from `config.nixfleet.trust` via environment.etc.
       '';
     };
 
-    releasePath = lib.mkOption {
-      type = lib.types.path;
-      default = "/var/lib/nixfleet-cp/fleet.git/releases/fleet.resolved.json";
+    freshnessWindowMinutes = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 1440;
       description = ''
-        Path to the resolved fleet artifact (fleet.resolved.json). v0.2
-        uses the local-checkout distribution pattern described in
-        docs/trust-root-flow.md §4 option (b): a separate systemd timer
-        keeps /var/lib/nixfleet-cp/fleet.git/ in sync with the fleet repo,
-        and the control plane reads the signed artifact from under it.
+        Maximum age (minutes) of `meta.signedAt` accepted by
+        `verify_artifact`. Match the operator-declared channel
+        `freshnessWindow` in fleet.nix when in doubt; default is 24h.
       '';
     };
 
-    openFirewall = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = "Open the control plane port in the firewall.";
-    };
-
-    tls = {
-      cert = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        default = null;
-        example = "/run/secrets/cp-cert.pem";
-        description = "Path to TLS certificate PEM file. Enables HTTPS when set (requires tls.key).";
-      };
-
-      key = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        default = null;
-        example = "/run/secrets/cp-key.pem";
-        description = "Path to TLS private key PEM file.";
-      };
-
-      clientCa = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        default = null;
-        example = "/run/secrets/fleet-ca.pem";
-        description = "Path to client CA PEM file. Enables mTLS agent authentication when set.";
-      };
+    tickIntervalMinutes = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 5;
+      description = ''
+        Minutes between reconcile ticks. In Phase 2 the runner is
+        side-effect-free (just emits a plan), so cadence is purely an
+        observability knob.
+      '';
     };
   };
 
   config = lib.mkMerge [
     (lib.mkIf cfg.enable {
-      assertions = [
-        {
-          assertion = builtins.match ".*:[0-9]+" cfg.listen != null;
-          message = ''
-            services.nixfleet-control-plane.listen must be in HOST:PORT format
-            (e.g. "0.0.0.0:8080"), got: "${cfg.listen}"
-          '';
-        }
-      ];
-
       environment.etc."nixfleet/cp/trust.json".source = trustJson;
 
       systemd.services.nixfleet-control-plane = {
-        description = "NixFleet Control Plane Server";
-        wantedBy = ["multi-user.target"];
-        after = ["network-online.target"];
-        wants = ["network-online.target"];
-
+        description = "NixFleet Phase 2 reconciler runner (one-shot)";
+        after = ["network.target"];
+        unitConfig.ConditionPathExists = cfg.artifactPath;
         serviceConfig = {
-          Type = "simple";
-          ExecStart = lib.concatStringsSep " " (
-            [
-              "${nixfleet-control-plane}/bin/nixfleet-control-plane"
-              "--listen"
-              (lib.escapeShellArg cfg.listen)
-              "--db-path"
-              (lib.escapeShellArg cfg.dbPath)
-              "--trust-file"
-              (lib.escapeShellArg (toString cfg.trustFile))
-              "--release-path"
-              (lib.escapeShellArg (toString cfg.releasePath))
-            ]
-            ++ lib.optionals (cfg.tls.cert != null) [
-              "--tls-cert"
-              (lib.escapeShellArg cfg.tls.cert)
-            ]
-            ++ lib.optionals (cfg.tls.key != null) [
-              "--tls-key"
-              (lib.escapeShellArg cfg.tls.key)
-            ]
-            ++ lib.optionals (cfg.tls.clientCa != null) [
-              "--client-ca"
-              (lib.escapeShellArg cfg.tls.clientCa)
-            ]
-          );
-          Restart = "always";
-          RestartSec = 10;
+          Type = "oneshot";
+          ExecStart = lib.concatStringsSep " " [
+            "${nixfleet-control-plane}/bin/nixfleet-control-plane"
+            "--artifact"
+            (lib.escapeShellArg cfg.artifactPath)
+            "--signature"
+            (lib.escapeShellArg cfg.signaturePath)
+            "--trust-file"
+            (lib.escapeShellArg (toString cfg.trustFile))
+            "--observed"
+            (lib.escapeShellArg cfg.observedPath)
+            "--freshness-window-secs"
+            (toString (cfg.freshnessWindowMinutes * 60))
+          ];
           StateDirectory = "nixfleet-cp";
 
-          # Hardening
-          NoNewPrivileges = true;
+          # Read-only against everything except its own state dir;
+          # writes nothing of consequence (output is on the journal).
+          DynamicUser = true;
+          ProtectSystem = "strict";
           ProtectHome = true;
           PrivateTmp = true;
           PrivateDevices = true;
           ProtectKernelTunables = true;
           ProtectKernelModules = true;
           ProtectControlGroups = true;
+          NoNewPrivileges = true;
+          RestrictAddressFamilies = ["AF_UNIX"];
+          # Reconciler is pure CPU + file reads — no network.
+          PrivateNetwork = true;
+          # Keeps the StateDirectory writable for future Phase 3 use;
+          # Phase 2 itself doesn't need to write there.
           ReadWritePaths = ["/var/lib/nixfleet-cp"];
         };
       };
 
-      # Open firewall port if requested
-      networking.firewall.allowedTCPPorts = let
-        port = lib.toInt (lib.last (lib.splitString ":" cfg.listen));
-      in
-        lib.mkIf cfg.openFirewall [port];
+      systemd.timers.nixfleet-control-plane = {
+        description = "NixFleet Phase 2 reconciler runner (timer)";
+        wantedBy = ["timers.target"];
+        timerConfig = {
+          OnBootSec = "30s";
+          OnUnitActiveSec = "${toString cfg.tickIntervalMinutes}m";
+          AccuracySec = "10s";
+          # Stagger across hosts in case multiple coordinators ever exist.
+          RandomizedDelaySec = "30s";
+        };
+      };
     })
 
-    # Impermanence: persist CP state across reboots. Outer mkIf so
-    # environment.persistence isn't referenced on non-impermanent hosts.
+    # Impermanence: persist CP state across reboots.
     (lib.mkIf (cfg.enable && (config.nixfleet.impermanence.enable or false)) {
       environment.persistence."/persist".directories = ["/var/lib/nixfleet-cp"];
     })

--- a/modules/scopes/nixfleet/_control-plane.nix
+++ b/modules/scopes/nixfleet/_control-plane.nix
@@ -23,6 +23,19 @@
   # and the orgRootKey ed25519 promotion that matches proto::TrustConfig.
   trustConfig = import ./_trust-json.nix {trust = config.nixfleet.trust;};
   trustJson = pkgs.writers.writeJSON "trust.json" trustConfig;
+
+  # First-deploy bootstrap for observed.json — laid down via
+  # systemd-tmpfiles `C+` (copy only if path does not exist) so the
+  # reconciler's first tick has a parseable file even before the
+  # operator has hand-written one. Operator can edit
+  # `cfg.observedPath` afterwards to populate channel refs / host
+  # state / active rollouts; subsequent rebuilds will not overwrite.
+  initialObservedJson = pkgs.writers.writeJSON "observed-initial.json" {
+    channelRefs = {};
+    lastRolledRefs = {};
+    hostState = {};
+    activeRollouts = [];
+  };
 in {
   options.services.nixfleet-control-plane = {
     enable = lib.mkEnableOption "NixFleet Phase 2 reconciler runner (read-only timer)";
@@ -134,6 +147,14 @@ in {
           ReadWritePaths = ["/var/lib/nixfleet-cp"];
         };
       };
+
+      # First-deploy auto-bootstrap of observed.json. tmpfiles `C+ … - <src>`
+      # copies from `<src>` only if `<target>` does not already exist —
+      # subsequent rebuilds leave operator-written content untouched.
+      systemd.tmpfiles.rules = [
+        "d /var/lib/nixfleet-cp 0755 root root -"
+        "C+ ${cfg.observedPath} 0644 root root - ${initialObservedJson}"
+      ];
 
       systemd.timers.nixfleet-control-plane = {
         description = "NixFleet Phase 2 reconciler runner (timer)";

--- a/modules/tests/_cp-v2-trust.nix
+++ b/modules/tests/_cp-v2-trust.nix
@@ -1,11 +1,15 @@
 # modules/tests/_cp-v2-trust.nix
 #
-# Eval-only assertions for the v0.2 control-plane scope module
-# (modules/scopes/nixfleet/_control-plane.nix). Mirrors
-# _agent-v2-trust.nix and additionally verifies:
-#   - --trust-file, --db-path, --release-path land on the ExecStart.
-#   - Default paths match the contract (trust.json under /etc/nixfleet/cp,
-#     release artifact under /var/lib/nixfleet-cp/fleet.git/releases).
+# Eval-only assertions for the Phase 2 control-plane scope module
+# (modules/scopes/nixfleet/_control-plane.nix). Verifies:
+#   - trust.json materialises at /etc/nixfleet/cp/trust.json
+#   - --artifact, --signature, --trust-file, --observed,
+#     --freshness-window-secs land on the ExecStart
+#   - Default paths match the Phase 2 contract
+#   - A timer unit is declared
+#
+# Phase 3 will graft wire endpoints (--listen, mTLS, db-path); update
+# this file when those flags re-enter the CLI surface.
 #
 # Called from modules/tests/eval.nix. Imported (not auto-imported by
 # import-tree) because the filename starts with an underscore.
@@ -18,6 +22,7 @@
   trustEtc = cfg.environment.etc."nixfleet/cp/trust.json";
   svcCfg = cfg.services.nixfleet-control-plane;
   trust = cfg.nixfleet.trust;
+  timer = cfg.systemd.timers.nixfleet-control-plane;
 in [
   {
     check = trustEtc ? source;
@@ -36,27 +41,51 @@ in [
     msg = "CP ExecStart carries --trust-file flag";
   }
   {
-    check = lib.hasInfix "--db-path" execStart;
-    msg = "CP ExecStart carries --db-path flag";
+    check = lib.hasInfix "--artifact" execStart;
+    msg = "CP ExecStart carries --artifact flag";
   }
   {
-    check = lib.hasInfix "--release-path" execStart;
-    msg = "CP ExecStart carries --release-path flag";
+    check = lib.hasInfix "--signature" execStart;
+    msg = "CP ExecStart carries --signature flag";
+  }
+  {
+    check = lib.hasInfix "--observed" execStart;
+    msg = "CP ExecStart carries --observed flag";
+  }
+  {
+    check = lib.hasInfix "--freshness-window-secs" execStart;
+    msg = "CP ExecStart carries --freshness-window-secs flag";
   }
   {
     check = lib.hasInfix "/etc/nixfleet/cp/trust.json" execStart;
     msg = "CP ExecStart passes the canonical trust-file path";
   }
   {
-    check = toString svcCfg.releasePath == "/var/lib/nixfleet-cp/fleet.git/releases/fleet.resolved.json";
-    msg = "CP releasePath defaults per trust-root-flow.md §4 option (b)";
+    check = svcCfg.artifactPath == "/var/lib/nixfleet-cp/fleet/releases/fleet.resolved.json";
+    msg = "CP artifactPath defaults under /var/lib/nixfleet-cp/fleet/releases/";
+  }
+  {
+    check = svcCfg.signaturePath == "/var/lib/nixfleet-cp/fleet/releases/fleet.resolved.json.sig";
+    msg = "CP signaturePath defaults pair with artifactPath";
+  }
+  {
+    check = svcCfg.observedPath == "/var/lib/nixfleet-cp/observed.json";
+    msg = "CP observedPath defaults under /var/lib/nixfleet-cp/";
   }
   {
     check = toString svcCfg.trustFile == "/etc/nixfleet/cp/trust.json";
     msg = "CP trustFile defaults to /etc/nixfleet/cp/trust.json";
   }
   {
-    check = svcCfg.dbPath == "/var/lib/nixfleet-cp/state.db";
-    msg = "CP dbPath defaults to /var/lib/nixfleet-cp/state.db";
+    check = cfg.systemd.services.nixfleet-control-plane.serviceConfig.Type == "oneshot";
+    msg = "CP service is oneshot (timer-driven, not long-running)";
+  }
+  {
+    check = timer.wantedBy == ["timers.target"];
+    msg = "CP timer is wantedBy timers.target";
+  }
+  {
+    check = lib.hasInfix "m" timer.timerConfig.OnUnitActiveSec;
+    msg = "CP timer OnUnitActiveSec is in minutes";
   }
 ]


### PR DESCRIPTION
## Summary

Lands the architecture doc's Phase 2 deliverable: ship the Rust reconciler from the spike, run it as a systemd timer on the M70q (lab), read \`fleet.resolved.json\` + a simulated \`observed.json\`, print the action plan to the journal. **No actions taken on the fleet** — the reconciler brain runs against operator-supplied observed state until Phase 3 wires real agent check-ins.

This PR is for the framework. The fleet-side trust-bootstrap (\`abstracts33d/fleet#…\`) and lab-enable change land separately.

## Commits

- \`feat(cp): Phase 2 reconciler runner (milestone 1: binary)\` — replaces the v0.2 control-plane skeleton with a one-shot reconciler runner. CLI: \`--artifact / --signature / --trust-file / --observed / --freshness-window-secs\`. Output: one summary JSON line + one JSON line per \`nixfleet_reconciler::Action\` (open_rollout / dispatch_host / promote_wave / converge_rollout / halt_rollout / skip), all on stdout. Cargo.toml slimmed to Phase 2 deps only — axum, tokio, rusqlite, rustls re-enter the surface in Phase 3 when the wire endpoints land.
- \`feat(cp): Phase 2 NixOS module + observed.json fixtures (milestone 2)\` — rewrites \`modules/scopes/nixfleet/_control-plane.nix\` for the timer + oneshot shape (no socket, no SQLite, no mTLS yet). \`_cp-v2-trust.nix\` eval-test rewritten with 16 assertions covering the new flag set + timer/oneshot shape. Three demo \`observed.json\` fixtures under \`crates/nixfleet-control-plane/fixtures/observed/\`.
- \`feat(cp): auto-bootstrap observed.json via systemd-tmpfiles C+\` — first-deploy DX: lay down an empty \`Observed\` JSON at \`cfg.observedPath\` so the first tick parses cleanly. \`C+\` copies only if the target doesn't exist — subsequent rebuilds leave operator-edited content untouched.

## Status

- 3 unit tests green in the runner crate.
- 16 eval-test assertions green via \`nix build .#checks.x86_64-linux.eval-nixfleet-cp-v2-trust\`.
- Smoke run against the harness signed fixture + each of the three demo observed fixtures: empty → 0 actions, fresh-rollout → 1 OpenRollout, in-progress → Skip-per-host as expected.
- \`cargo check --workspace\` clean, \`nix flake check --no-build\` clean.

## Test plan

- [ ] Reviewer re-runs \`nix build .#checks.x86_64-linux.eval-nixfleet-cp-v2-trust\` — expect green.
- [ ] \`cargo test -p nixfleet-control-plane\` passes.
- [ ] Smoke run: build the binary, point it at the harness signed fixture + \`crates/nixfleet-control-plane/fixtures/observed/empty.json\`, expect verify_ok=true and an empty plan.

## Notes

- This PR completes the architecture doc's Phase 2 deliverable. Phase 3 (agent skeletons reporting current generation) needs RFC-0003 §4.1 endpoints grafted onto this binary; observed.json gets replaced by a SQLite projection at that point.
- A \`nixfleet-verify-artifact\` thin CLI exists from PR #34 and is also useful for human debugging — leaving it as scaffold; v1 agent (parked on a side-bench branch) and the runner here both call \`nixfleet_reconciler::verify_artifact\` directly.
- The trust-root bootstrap (declaring \`ciReleaseKey.current\` from lab's TPM keyslot pubkey) is fleet-side; that PR is paired with this one. Until that lands, every tick on lab will log \`verify_ok=false reason=no-trust-roots\`.