### PR TITLE
docs(rfcs): annotate implementation status post-Phase 2

### DIFF
--- a/rfcs/0002-reconciler.md
+++ b/rfcs/0002-reconciler.md
@@ -1,8 +1,9 @@
 # RFC-0002: Rollout execution engine
 
-**Status.** Draft.
+**Status.** Partial — Phase 2 (read-only) shipped 2026-04-25. Full execution engine (state transitions, dispatch, rollback hooks) is Phase 4+.
 **Depends on.** RFC-0001 (`fleet.nix` schema), nixfleet #2 (magic rollback), nixfleet #4 (compliance gates).
 **Scope.** The decision procedure that turns `fleet.resolved` + observed fleet state into wave-by-wave reconciliation actions. Does not cover *how* actions reach hosts — that's RFC-0003.
+**Implementation status (2026-04-25).** A read-only reconciler runner ships in `crates/nixfleet-control-plane` and runs on the M70q (lab) as a systemd timer (PR #36). Each tick reads `releases/fleet.resolved.json` + a hand-written `observed.json`, calls `verify_artifact` (§4 step 0), calls `reconcile()` (§4 steps 1–6), and emits the action plan as JSON lines on the journal. **Actions are never executed in Phase 2** — the reconciler runs against operator-supplied observed state to validate the decision procedure. Dispatch, the per-host state machine (§3.2), `ConfirmWindow`, soak timers, and the `onHealthFailure` branches all land in Phase 4+ when activation is wired. Phase 3 replaces the file-backed `observed.json` with a SQLite projection updated by agent check-ins.
 
 ## 1. Motivation
 

--- a/rfcs/0003-protocol.md
+++ b/rfcs/0003-protocol.md
@@ -1,8 +1,9 @@
 # RFC-0003: Agent ↔ control-plane protocol
 
-**Status.** Draft.
+**Status.** Draft — end-state for Phase 3+. No wire is implemented yet.
 **Depends on.** RFC-0001, RFC-0002, nixfleet #2 (magic rollback).
 **Scope.** Wire protocol between agent and control plane. Identity, endpoints, polling, versioning, security properties. Does not cover control-plane-internal APIs.
+**Implementation status (2026-04-25).** No agent ↔ CP wire is implemented. The Phase 2 reconciler runner (RFC-0002 §0; PR #36) reads observed state from a hand-written `observed.json` file on disk; agents and check-in endpoints land in Phase 3 alongside this protocol. The identity model, endpoints, polling cadence, and TLS posture below are the forward plan, not the current contract. The `crates/nixfleet-agent` crate exists as a v0.2 skeleton (PR #29) only — no functional body, no network IO.
 
 ## 1. Design goals
 


### PR DESCRIPTION
## Summary

Adds an \`Implementation status\` paragraph to the front matter of RFC-0002 and RFC-0003 so a reader doesn't mistake the body for the current contract. Body of both RFCs unchanged — they remain Phase 4+ end-state docs.

## Why

Now that PR #36 has shipped the Phase 2 read-only reconciler runner, the gap between "what these RFCs describe" and "what's actually built" is wide enough that a fresh reader needs a pointer. Concretely:

- **RFC-0002** describes the full execution engine: dispatch, per-host state machine, ConfirmWindow, soak, rollback hooks. Today's runner only does \`verify_artifact\` (§4 step 0) + \`reconcile()\` (§4 steps 1–6). Actions are emitted to the journal, never executed. Phase 4+ wires the rest.
- **RFC-0003** describes the agent ↔ CP wire protocol with mTLS enrollment, polling, idempotent check-ins, magic-rollback confirm endpoint, etc. Today there is no wire at all — observed state is hand-written into a JSON file. Phase 3 wires the protocol.

## Test plan

- [ ] Reader scans the new front-matter paragraph and understands which sections are aspirational vs implemented.
- [ ] No body changes — diff is 4 insertions, 2 deletions across two files.