### PR TITLE
fix(cp): drop DynamicUser + use tmpfiles C (not C+) on observed.json

### DIFF
--- a/modules/scopes/nixfleet/_control-plane.nix
+++ b/modules/scopes/nixfleet/_control-plane.nix
@@ -126,11 +126,14 @@ in {
             "--freshness-window-secs"
             (toString (cfg.freshnessWindowMinutes * 60))
           ];
-          StateDirectory = "nixfleet-cp";
-
-          # Read-only against everything except its own state dir;
-          # writes nothing of consequence (output is on the journal).
-          DynamicUser = true;
+          # Phase 2 runs as root and writes nothing — tmpfiles seeds
+          # observed.json once at boot, the runner only reads. DynamicUser
+          # was an earlier draft, but combined with StateDirectory it
+          # forced systemd to migrate the existing /var/lib/nixfleet-cp
+          # into /var/lib/private/nixfleet-cp on first rebuild — that
+          # rename crosses bind-mount boundaries on impermanent hosts and
+          # fails with EXDEV. Phase 3 revisits when SQLite write state
+          # is introduced.
           ProtectSystem = "strict";
           ProtectHome = true;
           PrivateTmp = true;
@@ -142,18 +145,17 @@ in {
           RestrictAddressFamilies = ["AF_UNIX"];
           # Reconciler is pure CPU + file reads — no network.
           PrivateNetwork = true;
-          # Keeps the StateDirectory writable for future Phase 3 use;
-          # Phase 2 itself doesn't need to write there.
-          ReadWritePaths = ["/var/lib/nixfleet-cp"];
         };
       };
 
-      # First-deploy auto-bootstrap of observed.json. tmpfiles `C+ … - <src>`
-      # copies from `<src>` only if `<target>` does not already exist —
-      # subsequent rebuilds leave operator-written content untouched.
+      # First-deploy auto-bootstrap of observed.json. tmpfiles type `C`
+      # (without the `+` modifier) copies from the seed path only if the
+      # target does not already exist — operator edits to observed.json
+      # survive rebuilds. The `d` rule ensures the parent directory
+      # exists before the copy attempts.
       systemd.tmpfiles.rules = [
         "d /var/lib/nixfleet-cp 0755 root root -"
-        "C+ ${cfg.observedPath} 0644 root root - ${initialObservedJson}"
+        "C ${cfg.observedPath} 0644 root root - ${initialObservedJson}"
       ];
 
       systemd.timers.nixfleet-control-plane = {


### PR DESCRIPTION
## Summary

Two field-found bugs in the Phase 2 control-plane module (#36) surfaced
when the lab-enable PR (\`abstracts33d/fleet#46\`) tried to deploy on a
real impermanent host:

### 1. \`STATE_DIRECTORY\` cross-device error

\`DynamicUser=true\` + \`StateDirectory=nixfleet-cp\` triggers a systemd
migration on first rebuild from the v0.2 skeleton's previous placement
(\`/var/lib/nixfleet-cp\` owned by root) into the DynamicUser private
layout (\`/var/lib/private/nixfleet-cp\` + symlink back). The migration
uses \`rename(2)\`, which fails with \`EXDEV\` on impermanent hosts where
\`/var/lib\` and \`/var/lib/private\` straddle bind-mount boundaries.

Lab failed at \`status=238/STATE_DIRECTORY\` with:
\`Failed to set up special execution directory in /var/lib: Invalid cross-device link\`.

**Fix:** drop \`DynamicUser\`, \`StateDirectory\`, and \`ReadWritePaths\`.
Phase 2 is read-only — root + the rest of the hardening
(\`ProtectSystem=strict\`, \`ProtectHome\`, \`PrivateNetwork\`,
\`NoNewPrivileges\`, …) is sufficient. Phase 3 revisits this trade-off
when SQLite write state needs a privilege-separated user.

### 2. tmpfiles \`C+\` was wrong

\`+\` forces overwrite, which would clobber the operator's hand-edited
\`observed.json\` on every rebuild. Should be \`C\` alone (copy only if
target does not exist).

**Fix:** drop the \`+\`. Operator edits to
\`/var/lib/nixfleet-cp/observed.json\` now survive rebuilds.

## Test plan

- [x] \`nix build .#checks.x86_64-linux.eval-nixfleet-cp-v2-trust\` — green.
- [ ] After merge + fleet's nixfleet input bumped to this commit:
  \`nixos-rebuild switch --flake .#lab --target-host root@lab\` succeeds.
- [ ] First tick visible in \`journalctl -u nixfleet-control-plane.service\`
  with \`verify_ok=true, actions=0\` (the runner reads the auto-bootstrapped
  empty observed.json and finds nothing to reconcile).
- [ ] Manual \`echo '{...with channelRefs.stable...}' > /var/lib/nixfleet-cp/observed.json\`
  + wait one tick → \`open_rollout\` action appears.

## Notes

- Catch on this trade-off is documented in the module's serviceConfig
  comment so the next reviewer doesn't re-add DynamicUser without first
  thinking about cross-device migration.