### PR TITLE
fix(reconciler/tests): anchor reject_before_none_disables_the_gate to fixture signed_at

### DIFF
--- a/crates/nixfleet-reconciler/tests/verify.rs
+++ b/crates/nixfleet-reconciler/tests/verify.rs
@@ -561,9 +561,9 @@ fn accepts_artifact_signed_at_after_reject_before() {
 
 #[test]
 fn reject_before_none_disables_the_gate() {
-    let (bytes, sig, trust, _signed_at) = sign_artifact(FIXTURE_SIGNED);
+    let (bytes, sig, trust, signed_at) = sign_artifact(FIXTURE_SIGNED);
     let freshness = Duration::from_secs(86_400);
-    let now = Utc::now();
+    let now = signed_at + ChronoDuration::minutes(30);
 
     let _fleet = verify_artifact(
         &bytes,


### PR DESCRIPTION
## Summary

Two-line fix for a time-bomb test that started failing on 2026-04-25 once the wallclock crossed 24h past the fixture's ``meta.signedAt`` timestamp.

The test bound ``signed_at`` as ``_signed_at`` (unused) and used ``Utc::now()`` for the verifier's ``now`` parameter. The fixture's ``meta.signedAt`` is ``2026-04-24T10:00:00Z`` and the freshness window is 24h, so any test run more than 24h after that wallclock instant fails the staleness gate before reaching the ``reject_before`` check the test is asserting on.

Match the pattern every other test in this file uses: anchor ``now`` to ``signed_at + 30 minutes`` so the freshness gate is satisfied and the ``reject_before``-None branch is what actually decides the outcome.

## Why fast-track

Pre-existing latent bug. ``arcanesys/nixfleet:main`` has the same bug; this is the same fix that lives on the v0.2 lab chain (``chain/n4-phase2-cp-impl``). Without this on ``abstracts33d/main``, ``cargo nextest`` fails on a fresh clone of the fork.

## Test plan

- [x] ``cargo nextest run -p nixfleet-reconciler`` → 68/68 pass (verified locally + via pre-push hook).
- [ ] Once merged, ``lab/dev`` will be re-synced from ``origin/main``; chain/n4 tip and dev will then have matching trees.